### PR TITLE
Add techcommunity to unchecked URLs list

### DIFF
--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -101,6 +101,7 @@ def detect_issues(
                 "blog.gopenai.com",
                 "towardsdatascience.com",
                 "code.visualstudio.com",
+                "techcommunity.microsoft.com"
             ]
         )
         with concurrent.futures.ProcessPoolExecutor() as executor:


### PR DESCRIPTION
Unfortunately the new platform returns 400 with the programmatic requests:

>>> response = requests.head("https://techcommunity.microsoft.com/blog/azurearchitectureblog/azure-opena\
i-landing-zone-reference-architecture/3882102")
>>> response.status_code
400
>>> response
<Response [400]>

So I think it has to be added to the uncheckable list :(