### PR TITLE
Add skip_domains "opensource.org" in __init__.py

### DIFF
--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -101,6 +101,7 @@ def detect_issues(
                 "blog.gopenai.com",
                 "towardsdatascience.com",
                 "code.visualstudio.com",
+                "opensource.org",
             ]
         )
         with concurrent.futures.ProcessPoolExecutor() as executor:


### PR DESCRIPTION
Add skip_domains "opensource.org"

<!--
> We're eager to add your tutorial to this repository as soon as possible, but we need all samples to follow the same structure.
> _(DELETE THIS PARAGRAPH AFTER READING)_
-->

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | no                               |
| New tutorial?   | no                               |
| Related issues? | fixes #85|

## What's in this Pull Request?

there is an issue where the "opensource.org" domain is mistakenly detected as an error despite being a valid site.
Therefore, the address has been added to skip_domains.

 If there's anything incorrect, I'd appreciate it if you could let me know. Thank you!