### PR TITLE
Hotfix disable GitHub checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ### Other Changes
 
+## [v0.2.5] 5 May 2025
+
+- Disable GitHub.com URL checks (skipping until fixed)
+
 ## [v0.2.4] 26 Jan 2025
 
 - Increase timeout for requests to check web urls alive or not, defaults to 15 seconds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "markdown-checker"
 description= "A markdown link validation reporting tool."
-version = "0.2.4"
+version = "0.2.5"
 authors = [{ name = "John Aziz", email = "johnaziz269@gmail.com" }]
 maintainers = [{ name = "John Aziz", email = "johnaziz269@gmail.com" }]
 license = {file = "LICENSE"}

--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -85,6 +85,7 @@ def detect_issues(
                 "www.midjourney.com",
                 "www.linkedin.com",
                 "rodtrent.substack.com",
+                "github.com"
             ]
         )
         with concurrent.futures.ProcessPoolExecutor() as executor:


### PR DESCRIPTION
This pull request includes updates to disable GitHub.com URL checks, increment the project version, and document the changes in the changelog. Below are the most important changes grouped by theme:

### Feature Updates:
* [`src/markdown_checker/__init__.py`](diffhunk://#diff-d2b4d8703c07ceb7922183dd644c8c4f5bf160dfc0b5004c058f612db8c433e4R88): Added "github.com" to the list of URLs to be skipped during link validation.

### Versioning:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4): Updated the project version from `0.2.4` to `0.2.5`.

### Documentation:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR15-R18): Added an entry for version `v0.2.5`, noting the disabling of GitHub.com URL checks.