### PR TITLE
Release v1.0.1 with SRC argument, progress bar and timeout update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
 
 ### Other Changes
 
+## [v1.0.1] 18 April 2026
+
+- Add positional `SRC` argument as alternative to `--dir`, allowing users to pass individual files or directories directly.
+- Replace spinner with Click's built-in progress bar for checking progress.
+
 ## [v1.0.0] 13 April 2026
 
 ### Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Add positional `SRC` argument as alternative to `--dir`, allowing users to pass individual files or directories directly.
 - Replace spinner with Click's built-in progress bar for checking progress.
+- Update default timeout from 15s to 20s for better reliability.
 
 ## [v1.0.0] 13 April 2026
 

--- a/docs/source/advanced.md
+++ b/docs/source/advanced.md
@@ -160,7 +160,7 @@ markdown-checker -d . -f check_broken_urls --skip-urls-containing=/embed/,/previ
 
 - **Type**: `Click.IntRange`
 - **Description**: Timeout in seconds for the requests before retrying.
-- **Default**: `15`
+- **Default**: `20`
 - **Range**: `0-50`
 - **Required**: No
 

--- a/docs/source/advanced.md
+++ b/docs/source/advanced.md
@@ -32,11 +32,17 @@ markdown-checker -d . -f check_broken_urls --skip-domains=example.com,test.com
 
 ## Command Line Options
 
+### `SRC ...`
+
+- **Type**: `click.Path`
+- **Description**: Source files or directories to check.
+- **Required**: No (either `SRC` or `--dir` must be provided)
+
 ### `-d`, `--dir`
 
 - **Type**: `click.Path`
 - **Description**: Path to the root directory to check.
-- **Required**: Yes
+- **Required**: No (either `SRC` or `--dir` must be provided)
 
 ### `-f`, `--func`
 
@@ -130,10 +136,8 @@ markdown-checker -d . -f check_broken_urls --skip-domains=example.com,test.com
 ### `-suc`, `--skip-urls-containing`
 
 - **Type**: `list[str]`
-- **Description**: List of strings to skip checking if their urls are working or not.
-- **Default**:
-  - `https://www.microsoft.com/en-us/security/blog`
-  - `video-embed.html`
+- **Description**: List of urls to skip check.
+- **Default**: `[]`
 - **Required**: No
 
 **Usage Examples:**
@@ -173,12 +177,6 @@ markdown-checker -d . -f check_broken_urls --skip-urls-containing=/embed/,/previ
 - **Type**: `str`
 - **Description**: Name of the output file.
 - **Default**: `comment`
-- **Required**: No
-
-### `SRC ...`
-
-- **Type**: `click.Path`
-- **Description**: Source files or directories to check.
 - **Required**: No
 
 ## Other Options

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-disable MD041 -->
+- [Checker](./api/checker.md)
+- [Checks](./api/checks.md)
+- [CLI](./api/cli.md)
 - [Main](./api/main.md)
 - [Models](./api/models.md)
-- [Checks](./api/checks.md)
 - [Reports](./api/reports.md)
 - [Utilities](./api/utils.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "markdown-checker"
 description= "A markdown link validation reporting tool."
-version = "1.0.0"
+version = "1.0.1"
 authors = [{ name = "John Aziz", email = "johnaziz269@gmail.com" }]
 maintainers = [{ name = "John Aziz", email = "johnaziz269@gmail.com" }]
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ filterwarnings = ["ignore::DeprecationWarning"]
 show_missing = true
 
 [project.scripts]
-markdown-checker = "markdown_checker:main_with_spinner"
+markdown-checker = "markdown_checker:main"
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -2,7 +2,7 @@
 markdown-checker — a markdown link validation reporting tool.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from markdown_checker.cli import main
 from markdown_checker.models import Config, MarkdownLinkBase, MarkdownPath, MarkdownURL

--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -4,7 +4,7 @@ markdown-checker — a markdown link validation reporting tool.
 
 __version__ = "1.0.0"
 
-from markdown_checker.cli import main, main_with_spinner
+from markdown_checker.cli import main
 from markdown_checker.models import Config, MarkdownLinkBase, MarkdownPath, MarkdownURL
 
-__all__ = ["Config", "main", "main_with_spinner", "MarkdownLinkBase", "MarkdownPath", "MarkdownURL", "__version__"]
+__all__ = ["Config", "main", "MarkdownLinkBase", "MarkdownPath", "MarkdownURL", "__version__"]

--- a/src/markdown_checker/checker.py
+++ b/src/markdown_checker/checker.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -51,6 +52,7 @@ def run_check_on_files(
     func: str,
     files_paths: list[Path],
     config: Config,
+    progress_callback: Callable[[], None],
 ) -> CheckResult:
     """
     Run a named check across multiple files.
@@ -59,6 +61,7 @@ def run_check_on_files(
         func: Name of the check to run (must be a key in REGISTRY).
         files_paths: List of markdown file paths to check.
         config: Runtime configuration for the check.
+        progress_callback: Callback invoked after each file is checked.
 
     Returns:
         A CheckResult with per-file issues and total links checked.
@@ -74,5 +77,6 @@ def run_check_on_files(
         result.links_checked += links_count
         if detected_issues:
             result.issues.append((file_path, detected_issues))
+        progress_callback()
 
     return result

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -119,7 +119,7 @@ class ListOfStrings(click.Option):
     "-to",
     "--timeout",
     type=click.IntRange(0, 50),
-    default=15,
+    default=20,
     help="Timeout in seconds for the requests.",
     required=False,
 )

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -32,12 +32,19 @@ class ListOfStrings(click.Option):
 
 
 @click.command()
+@click.argument(
+    "src",
+    nargs=-1,
+    type=click.Path(path_type=Path, exists=True, file_okay=True, dir_okay=True, readable=True),
+    metavar="SRC ...",
+    required=False,
+)
 @click.option(
     "-d",
     "--dir",
     type=click.Path(path_type=Path, exists=True, file_okay=False, dir_okay=True, readable=True),
     help="Path to the root directory to check.",
-    required=True,
+    required=False,
 )
 @click.option(
     "-f",
@@ -139,7 +146,8 @@ class ListOfStrings(click.Option):
 @click.pass_context
 def main(
     ctx: click.Context,
-    dir: Path,
+    src: tuple[Path, ...],
+    dir: Path | None,
     func: str,
     guide_url: str | None,
     extensions: list[str],
@@ -152,7 +160,18 @@ def main(
     output_file_name: str,
 ) -> None:
     """A markdown link validation reporting tool."""
-    _, files_paths = get_files_paths_list(dir, extensions)
+    if src:
+        files_paths = []
+        for p in src:
+            if p.is_dir():
+                _, dir_files = get_files_paths_list(p, extensions)
+                files_paths.extend(dir_files)
+            elif p.suffix.lower() in extensions:
+                files_paths.append(p)
+    elif dir is not None:
+        _, files_paths = get_files_paths_list(dir, extensions)
+    else:
+        raise click.UsageError("Either SRC or --dir must be provided.")
 
     # remove files from skip_files list
     files_paths = [file_path for file_path in files_paths if file_path.name not in skip_files]

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -9,7 +9,6 @@ from markdown_checker.models.config import Config
 from markdown_checker.reports.format_output import format_issues_table
 from markdown_checker.reports.markdown import MarkdownGenerator
 from markdown_checker.utils.list_files import get_files_paths_list
-from markdown_checker.utils.spinner import spinner
 
 
 class ListOfStrings(click.Option):
@@ -185,11 +184,13 @@ def main(
         output_mode="ci" if os.getenv("CI", "false") == "true" else "local",
     )
 
-    check_result = run_check_on_files(
-        func=func,
-        files_paths=files_paths,
-        config=config,
-    )
+    with click.progressbar(length=len(files_paths), label="Checking", hidden=config.output_mode == "ci") as bar:
+        check_result = run_check_on_files(
+            func=func,
+            files_paths=files_paths,
+            config=config,
+            progress_callback=lambda: bar.update(1),
+        )
 
     click.echo(
         click.style(f"\n🔍 Checked {check_result.links_checked} links in {len(files_paths)} files.", fg="blue"),
@@ -228,8 +229,3 @@ def main(
 
     click.echo(click.style("All files are compliant with the guidelines. 🎉", fg="green"), err=False)
     ctx.exit(0)
-
-
-def main_with_spinner() -> None:
-    with spinner():
-        main()

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -144,6 +144,7 @@ def test_run_check_on_files(tmp_path):
         func="check_broken_paths",
         files_paths=[md1, md2],
         config=Config(),
+        progress_callback=lambda: None,
     )
     assert len(result.issues) == 1
     assert result.issues[0][0] == md1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,7 @@ def test_cli_version(runner):
     """Displays version information."""
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0
-    assert "1.0.0" in result.output
+    assert "1.0.1" in result.output
 
 
 def test_cli_ci_mode(runner, resources_dir, monkeypatch, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,3 +152,66 @@ def test_cli_ci_mode(runner, resources_dir, monkeypatch, tmp_path):
         ["-d", str(resources_dir), "-f", "check_broken_paths", "-o", str(tmp_path / "ci_output")],
     )
     assert result.exit_code == 0
+
+
+# --- SRC positional argument ---
+
+
+def test_cli_src_single_file(runner, resources_dir):
+    """Runs check on a single file passed as SRC."""
+    sample = resources_dir / "sample1.md"
+    result = runner.invoke(main, [str(sample), "-f", "check_broken_paths"])
+    assert result.exit_code == 0
+    assert "Checked" in result.output
+    assert "1 files" in result.output
+
+
+def test_cli_src_multiple_files(runner, resources_dir):
+    """Runs check on multiple files passed as SRC."""
+    s1 = resources_dir / "sample1.md"
+    s2 = resources_dir / "sample2.md"
+    result = runner.invoke(main, [str(s1), str(s2), "-f", "check_broken_paths"])
+    assert result.exit_code == 0
+    assert "Checked" in result.output
+    assert "2 files" in result.output
+
+
+def test_cli_src_directory(runner, resources_dir):
+    """Passing a directory as SRC recursively discovers files."""
+    result = runner.invoke(main, [str(resources_dir), "-f", "check_broken_paths"])
+    assert result.exit_code == 0
+    assert "Checked" in result.output
+
+
+def test_cli_src_mixed_file_and_dir(runner, resources_dir, tmp_path):
+    """Passing both a file and a directory as SRC combines results."""
+    extra = tmp_path / "extra.md"
+    extra.write_text("# Extra\n[link](https://example.com)\n")
+    result = runner.invoke(main, [str(extra), str(resources_dir), "-f", "check_broken_paths"])
+    assert result.exit_code == 0
+    assert "Checked" in result.output
+
+
+def test_cli_src_filters_by_extension(runner, tmp_path):
+    """SRC files not matching --extensions are ignored."""
+    md_file = tmp_path / "valid.md"
+    md_file.write_text("# Hello\n")
+    txt_file = tmp_path / "ignored.txt"
+    txt_file.write_text("# Not checked\n")
+    result = runner.invoke(main, [str(md_file), str(txt_file), "-f", "check_broken_paths", "-ext", ".md"])
+    assert result.exit_code == 0
+    assert "1 files" in result.output
+
+
+def test_cli_src_takes_precedence_over_dir(runner, resources_dir, tmp_path):
+    """When SRC is provided, --dir is ignored."""
+    sample = resources_dir / "sample1.md"
+    result = runner.invoke(main, [str(sample), "-d", str(resources_dir), "-f", "check_broken_paths"])
+    assert result.exit_code == 0
+    assert "1 files" in result.output
+
+
+def test_cli_no_src_no_dir_fails(runner):
+    """Fails when neither SRC nor --dir is provided."""
+    result = runner.invoke(main, ["-f", "check_broken_paths"])
+    assert result.exit_code != 0

--- a/uv.lock
+++ b/uv.lock
@@ -524,7 +524,7 @@ wheels = [
 
 [[package]]
 name = "markdown-checker"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request introduces a new way to specify source files or directories to check, improves the user experience with a progress bar, and updates documentation and tests to reflect these changes. It also increases the default timeout for requests and removes the custom spinner in favor of Click's built-in progress bar.

Partial fix #114 

**CLI and User Experience Improvements:**

* Adds a positional `SRC` argument to the CLI as an alternative to `--dir`, allowing users to specify individual files or directories directly. If both are provided, `SRC` takes precedence. The CLI now requires at least one of `SRC` or `--dir`. [[1]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcR34-R46) [[2]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcL142-R149) [[3]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcR162-R173) [[4]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcR187-R192) [[5]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR155-R217) [[6]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfR35-R45)
* Replaces the custom spinner with Click's built-in progress bar for file-checking progress, simplifying the code and improving feedback. [[1]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcL12) [[2]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcR187-R192) [[3]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcL212-L216)
* Increases the default request timeout from 15s to 20s for improved reliability. [[1]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcL116-R122) [[2]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfL159-R163)

**Codebase and API Changes:**

* Updates the `run_check_on_files` function to accept a `progress_callback`, which is invoked after each file is checked, enabling integration with the progress bar. [[1]](diffhunk://#diff-bb0faa22cfb29f9da1660ddf28b3a02b922de2d3f97079e824c64a588782f0baR55) [[2]](diffhunk://#diff-bb0faa22cfb29f9da1660ddf28b3a02b922de2d3f97079e824c64a588782f0baR64) [[3]](diffhunk://#diff-bb0faa22cfb29f9da1660ddf28b3a02b922de2d3f97079e824c64a588782f0baR80) [[4]](diffhunk://#diff-35c2c975594deff3b752aa656843540afa1a28c37f8e5e4ffb3e8b719464c027R147)
* Removes the `main_with_spinner` entry point and related code, consolidating the CLI entry to `main`. [[1]](diffhunk://#diff-aa40526f3d3569c57a0a92c9de7060ee6e92ec4366013601aafd586059a789fcL212-L216) F36ebb94L1R1, [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L89-R89)

**Documentation Updates:**

* Updates CLI documentation to describe the new `SRC` argument, clarify the relationship between `SRC` and `--dir`, and reflect the new default timeout and other minor option clarifications. [[1]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfR35-R45) [[2]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfL133-R140) [[3]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfL159-R163) [[4]](diffhunk://#diff-8ea325f171f5cd6ee84fe6d052f0f8b521bb10cdaa60f3607f317131022804bfL178-L183)
* Adds missing API documentation links for `Checker`, `Checks`, and `CLI`.

**Testing:**

* Adds comprehensive tests for the new `SRC` argument, including cases for single/multiple files, directories, mixed input, precedence over `--dir`, extension filtering, and error handling when neither `SRC` nor `--dir` is provided.

**Versioning and Changelog:**

* Bumps the project version to `1.0.1` and updates the changelog to summarize these changes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4) F36ebb94L1R1, [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR15-R20) [[3]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL143-R143)

These changes collectively make the CLI more flexible and user-friendly, streamline progress reporting, and ensure documentation and tests are up to date.