### PR TITLE
feat: Add Retry-After header support for rate-limited requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 -------------------
 
 - Migrate to ``httpx2``.
+- Support following ``Retry-After`` headers for rate-limited requests.
 
 
 [v1.0.2] 4 May 2026

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -231,6 +231,60 @@ Range
 Required
   No.
 
+``--retry-on-429`` / ``--no-retry-on-429``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type
+  ``bool``
+Description
+  When enabled, the checker honours the ``Retry-After`` response header on
+  ``429 Too Many Requests`` (and any other non-success, non-redirect response
+  that carries the header). The indicated wait time is used instead of the
+  normal exponential backoff. Disable with ``--no-retry-on-429`` to fall back
+  to standard retry behaviour.
+Default
+  Enabled (``--retry-on-429``)
+Required
+  No.
+
+Usage examples
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  # Enabled (default)
+  markdown-checker -d . -f check_broken_urls --retry-on-429
+
+  # Disabled
+  markdown-checker -d . -f check_broken_urls --no-retry-on-429
+
+``-frd``, ``--fallback-retry-delay``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type
+  ``Click.IntRange``
+Description
+  Number of seconds to wait before retrying when a ``429`` response is
+  received but carries no ``Retry-After`` header. Only applies when
+  ``--retry-on-429`` is enabled.
+Default
+  ``30``
+Range
+  ``0-300``
+Required
+  No.
+
+Usage examples
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  # Use a custom fallback delay of 45 seconds
+  markdown-checker -d . -f check_broken_urls --fallback-retry-delay=45
+
+  # Short-form alias
+  markdown-checker -d . -f check_broken_urls -frd 45
+
 ``-o``, ``--output-file-name``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/markdown_checker/checks/broken_urls.py
+++ b/src/markdown_checker/checks/broken_urls.py
@@ -20,6 +20,8 @@ def _check_url(
     skip_urls_containing: list[str],
     timeout: int,
     retries: int,
+    retry_on_429: bool,
+    fallback_retry_delay: int,
 ) -> MarkdownURL | None:
     """Thread worker: checks a single URL with its own httpx2 client."""
     hostname = url.host_name().lower()
@@ -28,7 +30,12 @@ def _check_url(
     ):
         return None
     # Each worker creates its own client via is_alive(client=None).
-    if not url.is_alive(timeout=timeout, retries=retries):
+    if not url.is_alive(
+        timeout=timeout,
+        retries=retries,
+        retry_on_429=retry_on_429,
+        fallback_retry_delay=fallback_retry_delay,
+    ):
         url.issue = "is broken"
         return url
     return None
@@ -55,6 +62,8 @@ class BrokenURLsCheck(BaseCheck):
             skip_urls_containing=skip_urls_containing,
             timeout=config.timeout,
             retries=config.retries,
+            retry_on_429=config.retry_on_429,
+            fallback_retry_delay=config.fallback_retry_delay,
         )
         # NOTE: httpx2.Client is NOT thread-safe. Do not share a single client
         # across ThreadPoolExecutor workers. Each worker creates its own

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -132,6 +132,19 @@ class ListOfStrings(click.Option):
     required=False,
 )
 @click.option(
+    "--retry-on-429/--no-retry-on-429",
+    default=True,
+    help="Honour Retry-After headers when a 429 response is received.",
+)
+@click.option(
+    "-frd",
+    "--fallback-retry-delay",
+    type=click.IntRange(0, 300),
+    default=30,
+    help="Fallback delay in seconds when a 429 response has no Retry-After header.",
+    required=False,
+)
+@click.option(
     "-o",
     "--output-file-name",
     type=str,
@@ -156,6 +169,8 @@ def main(
     tracking_domains: list[str],
     timeout: int,
     retries: int,
+    retry_on_429: bool,
+    fallback_retry_delay: int,
     output_file_name: str,
 ) -> None:
     """A markdown link validation reporting tool."""
@@ -181,6 +196,8 @@ def main(
         tracking_domains=tracking_domains,
         timeout=timeout,
         retries=retries,
+        retry_on_429=retry_on_429,
+        fallback_retry_delay=fallback_retry_delay,
         output_mode="ci" if os.getenv("CI", "false") == "true" else "local",
     )
 

--- a/src/markdown_checker/models/config.py
+++ b/src/markdown_checker/models/config.py
@@ -28,4 +28,6 @@ class Config:
     tracking_domains: list[str] = field(default_factory=list)
     timeout: int = 20
     retries: int = 3
+    retry_on_429: bool = True
+    fallback_retry_delay: int = 30
     output_mode: Literal["ci", "local"] = "local"

--- a/src/markdown_checker/models/url.py
+++ b/src/markdown_checker/models/url.py
@@ -1,5 +1,8 @@
+import email.utils
 import time
 from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
 
@@ -7,6 +10,36 @@ import httpx2
 
 from markdown_checker.models.base import MarkdownLinkBase
 from markdown_checker.models.config import create_http_client
+
+
+def _retry_after_delay(response: httpx2.Response, fallback: int) -> float | None:
+    """Return seconds to sleep if the response warrants a Retry-After wait.
+
+    Returns None when normal exponential backoff should be used instead.
+    """
+    is_429 = response.status_code == 429
+    has_retry_after = "retry-after" in response.headers
+    triggered = is_429 or (not response.is_success and not response.is_redirect and has_retry_after)
+    if not triggered:
+        return None
+
+    header = response.headers.get("retry-after")
+    if header:
+        # Try integer seconds first.
+        try:
+            return float(header.strip())
+        except ValueError:
+            pass
+        # Try HTTP-date format (e.g. "Wed, 21 Oct 2015 07:28:00 GMT").
+        try:
+            dt = email.utils.parsedate_to_datetime(header)
+            now = datetime.now(timezone.utc)
+            delay = (dt - now).total_seconds()
+            return max(0.0, delay)
+        except Exception:
+            pass
+
+    return float(fallback)
 
 
 @dataclass(slots=True)
@@ -29,7 +62,14 @@ class MarkdownURL(MarkdownLinkBase):
         """
         return self.parsed_url.netloc
 
-    def is_alive(self, timeout: int = 20, retries: int = 3, client: httpx2.Client | None = None) -> bool:
+    def is_alive(
+        self,
+        timeout: int = 20,
+        retries: int = 3,
+        client: httpx2.Client | None = None,
+        retry_on_429: bool = True,
+        fallback_retry_delay: int = 30,
+    ) -> bool:
         """
         Check if the URL is alive
 
@@ -37,6 +77,8 @@ class MarkdownURL(MarkdownLinkBase):
             timeout (int): Timeout for the request in seconds.
             retries (int): Number of retries if the request fails.
             client (httpx2.Client | None): Optional shared client for connection pooling.
+            retry_on_429 (bool): When True, honour Retry-After headers on 429 responses.
+            fallback_retry_delay (int): Seconds to wait when a 429 carries no Retry-After header.
 
         Returns:
             bool: True if the URL is alive, False otherwise
@@ -44,13 +86,19 @@ class MarkdownURL(MarkdownLinkBase):
         _client = client or create_http_client()
         try:
             for attempt in range(retries):
+                sleep_override: float | None = None
                 try:
                     response = _client.head(self.link, timeout=timeout)
                     if response.is_success:
                         return True
-                    response = _client.get(self.link, timeout=timeout)
-                    if response.is_success:
-                        return True
+                    if retry_on_429:
+                        sleep_override = _retry_after_delay(response, fallback_retry_delay)
+                    if sleep_override is None:
+                        response = _client.get(self.link, timeout=timeout)
+                        if response.is_success:
+                            return True
+                        if retry_on_429:
+                            sleep_override = _retry_after_delay(response, fallback_retry_delay)
                 except httpx2.UnsupportedProtocol:
                     # Server redirected to a non-HTTP scheme (e.g. vscode://).
                     # The original URL is reachable; treat it as alive.
@@ -58,7 +106,10 @@ class MarkdownURL(MarkdownLinkBase):
                 except (httpx2.HTTPError, RuntimeError):
                     pass
                 if attempt < retries - 1:
-                    time.sleep(0.5 * 2**attempt)
+                    if sleep_override is not None:
+                        time.sleep(sleep_override)
+                    else:
+                        time.sleep(0.5 * 2**attempt)
         finally:
             if client is None:
                 _client.close()

--- a/tests/test_checks_broken_urls.py
+++ b/tests/test_checks_broken_urls.py
@@ -83,7 +83,15 @@ def test_skip_urls_containing(check, make_markdown_url, make_markdown_links):
 def test_check_url_returns_none_for_skipped_domain():
     """Returns None for URLs on skipped domains."""
     url = MarkdownURL(link="https://github.com/page", line_number=1, file_path=Path("test.md"))
-    result = _check_url(url, skip_domains=["github.com"], skip_urls_containing=[], timeout=5, retries=1)
+    result = _check_url(
+        url,
+        skip_domains=["github.com"],
+        skip_urls_containing=[],
+        timeout=5,
+        retries=1,
+        retry_on_429=True,
+        fallback_retry_delay=60,
+    )
     assert result is None
 
 
@@ -91,7 +99,15 @@ def test_check_url_returns_url_for_broken():
     """Returns the URL with issue set when it is not alive."""
     url = MarkdownURL(link="https://broken.example.com", line_number=1, file_path=Path("test.md"))
     with patch.object(MarkdownURL, "is_alive", return_value=False):
-        result = _check_url(url, skip_domains=[], skip_urls_containing=[], timeout=5, retries=1)
+        result = _check_url(
+            url,
+            skip_domains=[],
+            skip_urls_containing=[],
+            timeout=5,
+            retries=1,
+            retry_on_429=True,
+            fallback_retry_delay=60,
+        )
     assert result is not None
     assert result.issue == "is broken"
 
@@ -100,7 +116,15 @@ def test_check_url_returns_none_for_alive():
     """Returns None for alive URLs."""
     url = MarkdownURL(link="https://alive.example.com", line_number=1, file_path=Path("test.md"))
     with patch.object(MarkdownURL, "is_alive", return_value=True):
-        result = _check_url(url, skip_domains=[], skip_urls_containing=[], timeout=5, retries=1)
+        result = _check_url(
+            url,
+            skip_domains=[],
+            skip_urls_containing=[],
+            timeout=5,
+            retries=1,
+            retry_on_429=True,
+            fallback_retry_delay=60,
+        )
     assert result is None
 
 

--- a/tests/test_models_url.py
+++ b/tests/test_models_url.py
@@ -100,6 +100,96 @@ def test_is_alive_runtime_error_returns_false():
     assert mock_client.head.call_count == 2
 
 
+def _make_response(status_code: int, headers: dict | None = None) -> MagicMock:
+    """Build a mock httpx2.Response with the given status code and headers."""
+    resp = MagicMock(spec=httpx2.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.is_redirect = 300 <= status_code < 400
+    resp.headers = headers or {}
+    return resp
+
+
+def test_is_alive_429_with_retry_after_integer_sleeps_and_retries():
+    """429 + Retry-After: 2 → sleep(2) called, request retried, returns True on success."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "2"})
+    success = _make_response(200)
+    success.is_success = True
+    mock_client.head.side_effect = [rate_limited, success]
+
+    with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
+        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+
+    assert result is True
+    mock_sleep.assert_called_once_with(2.0)
+    assert mock_client.head.call_count == 2
+
+
+def test_is_alive_429_without_retry_after_uses_fallback():
+    """429 with no Retry-After header → sleep(fallback_retry_delay) called."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {})
+    success = _make_response(200)
+    mock_client.head.side_effect = [rate_limited, success]
+
+    with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
+        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+
+    assert result is True
+    mock_sleep.assert_called_once_with(30.0)
+
+
+def test_is_alive_429_retry_succeeds_no_issue():
+    """After a 429, a successful retry means is_alive returns True (no issue set)."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "1"})
+    success = _make_response(200)
+    mock_client.head.side_effect = [rate_limited, success]
+
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+
+    assert result is True
+    assert url.issue == ""
+
+
+def test_is_alive_retry_on_429_disabled_uses_exponential_backoff():
+    """When retry_on_429=False, a 429 response uses normal exponential backoff."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "999"})
+    rate_limited_get = _make_response(429, {"retry-after": "999"})
+    success = _make_response(200)
+    mock_client.head.side_effect = [rate_limited, success]
+    mock_client.get.return_value = rate_limited_get
+
+    with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
+        url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=False, fallback_retry_delay=60)
+
+    # Should use exponential backoff (0.5 * 2^0 = 0.5), NOT the Retry-After value.
+    mock_sleep.assert_called_once_with(0.5)
+
+
+def test_is_alive_non_success_with_retry_after_header_uses_delay():
+    """Any non-success, non-redirect response with Retry-After is respected."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    # 503 with Retry-After: 5 should also trigger the delay.
+    throttled = _make_response(503, {"retry-after": "5"})
+    success = _make_response(200)
+    mock_client.head.side_effect = [throttled, success]
+
+    with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
+        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+
+    assert result is True
+    mock_sleep.assert_called_once_with(5.0)
+
+
 def test_is_alive_creates_client_when_none():
     """Creates and closes its own httpx2.Client when none is provided."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))


### PR DESCRIPTION
Respect the Retry-After header on 429 responses instead of falling back to exponential backoff.

Introduces two new options: `--retry-on-429` (enabled by default) to toggle this behaviour, and `--fallback-retry-delay` to control the wait time when no Retry-After header is present.

related #122 