### PR TITLE
feat: structured url outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 - Support following ``Retry-After`` headers for rate-limited requests.
 - Adds granular URL check outcomes with warning-level issues for
   rate-limited URLs instead of treating them as broken.
+- Treat 401 and 403 responses as unverifiable with appropriate issue messages instead
+  of flagging as broken.
 
 
 [v1.0.2] 4 May 2026

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Migrate to ``httpx2``.
 - Support following ``Retry-After`` headers for rate-limited requests.
+- Adds granular URL check outcomes with warning-level issues for
+  rate-limited URLs instead of treating them as broken.
 
 
 [v1.0.2] 4 May 2026

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -297,6 +297,63 @@ Default
 Required
   No.
 
+URL Check Outcomes
+------------------
+
+When ``check_broken_urls`` runs, each URL is evaluated by
+``MarkdownURL.check()``, which returns a ``URLCheckResult`` with one of four
+statuses.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Status
+     - Meaning
+   * - ``alive``
+     - A ``2xx`` HTTP response was received. The link is healthy.
+   * - ``broken``
+     - All retries returned non-``2xx`` responses (e.g. ``404 Not Found``).
+       The link is reported as an issue.
+   * - ``rate_limited``
+     - No hard HTTP failure was observed, and at least one retry encountered
+       ``429 Too Many Requests`` (with or without a ``Retry-After`` header).
+       The link is reported as a **warning-level issue**
+       (``issue_level="warning"``). It does not cause the CLI to exit with a
+       non-zero code.
+   * - ``transient_error``
+     - No hard HTTP failure or rate-limit response was observed, and the
+       attempts failed with network-level exceptions (e.g. DNS failure,
+       connection timeout). The link is reported as a **warning-level issue**
+       and does not cause the CLI to exit with a non-zero code.
+
+Rate limiting
+~~~~~~~~~~~~~
+
+When one or more URLs are rate-limited or cannot be reached due to transient
+network failures, the CLI prints a yellow warning summary followed by one
+warning line per affected link, after the error-level issues (if any).
+
+In local mode::
+
+  🔍 Checked 42 links in 10 files.
+  ⚠ 3 links had warnings:
+  	File '/path/to/file.md', line 12
+  https://example.com/api was skipped due to rate limiting.
+
+In CI mode (``$CI=true``), GitHub Actions ``::warning::`` annotations are
+emitted instead::
+
+  🔍 Checked 42 links in 10 files.
+  ::warning file=path/to/file.md,line=12::File path/to/file.md, line 12, Link https://example.com/api was skipped due to rate limiting.
+
+Warning-level issues do **not** cause the CLI to exit with a non-zero code.
+Only error-level issues (broken links) cause a non-zero exit.
+
+If a run mixes rate-limited responses with transient network failures, the
+outcome is reported as ``rate_limited`` unless a hard HTTP failure is also
+observed. Any hard HTTP failure causes the final outcome to be ``broken``.
+
 Other Options
 -------------
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -301,7 +301,7 @@ URL Check Outcomes
 ------------------
 
 When ``check_broken_urls`` runs, each URL is evaluated by
-``MarkdownURL.check()``, which returns a ``URLCheckResult`` with one of four
+``MarkdownURL.check()``, which returns a ``URLCheckResult`` with one of five
 statuses.
 
 .. list-table::
@@ -326,13 +326,19 @@ statuses.
        attempts failed with network-level exceptions (e.g. DNS failure,
        connection timeout). The link is reported as a **warning-level issue**
        and does not cause the CLI to exit with a non-zero code.
+   * - ``unverifiable``
+     - Both HEAD and GET returned ``401 Unauthorized`` or ``403 Forbidden``.
+       The server is reachable but is blocking automated access (e.g.
+       Cloudflare bot protection). The real status of the resource cannot be
+       determined. The link is reported as a **warning-level issue** and does
+       not cause the CLI to exit with a non-zero code.
 
-Rate limiting
-~~~~~~~~~~~~~
+Rate limiting and access errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When one or more URLs are rate-limited or cannot be reached due to transient
-network failures, the CLI prints a yellow warning summary followed by one
-warning line per affected link, after the error-level issues (if any).
+When one or more URLs are rate-limited, unverifiable, or cannot be reached due
+to transient network failures, the CLI prints a yellow warning summary followed
+by one warning line per affected link, after the error-level issues (if any).
 
 In local mode::
 
@@ -341,11 +347,15 @@ In local mode::
   	File '/path/to/file.md', line 12
   https://example.com/api was skipped due to rate limiting.
 
+  	File '/path/to/file.md', line 15
+  https://stackoverflow.com/a/123 could not be verified (access was forbidden by the server).
+
 In CI mode (``$CI=true``), GitHub Actions ``::warning::`` annotations are
 emitted instead::
 
   🔍 Checked 42 links in 10 files.
   ::warning file=path/to/file.md,line=12::File path/to/file.md, line 12, Link https://example.com/api was skipped due to rate limiting.
+  ::warning file=path/to/file.md,line=15::File path/to/file.md, line 15, Link https://stackoverflow.com/a/123 could not be verified (access was forbidden by the server).
 
 Warning-level issues do **not** cause the CLI to exit with a non-zero code.
 Only error-level issues (broken links) cause a non-zero exit.

--- a/src/markdown_checker/checks/__init__.py
+++ b/src/markdown_checker/checks/__init__.py
@@ -4,9 +4,10 @@ from markdown_checker.checks.broken_urls import BrokenURLsCheck
 from markdown_checker.checks.locale import URLsLocaleCheck
 from markdown_checker.checks.tracking import PathsTrackingCheck
 from markdown_checker.checks.tracking import URLsTrackingCheck
+from markdown_checker.models import MarkdownLinkBase
 
 # Maps the CLI --func argument value to the corresponding check instance.
-REGISTRY: dict[str, BaseCheck] = {
+REGISTRY: dict[str, BaseCheck[MarkdownLinkBase]] = {
     BrokenPathsCheck.name: BrokenPathsCheck(),
     BrokenURLsCheck.name: BrokenURLsCheck(),
     URLsTrackingCheck.name: URLsTrackingCheck(),

--- a/src/markdown_checker/checks/base.py
+++ b/src/markdown_checker/checks/base.py
@@ -1,13 +1,17 @@
 from abc import ABC
 from abc import abstractmethod
+from typing import Generic
 from typing import Literal
+from typing import TypeVar
 
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownLinkBase
 from markdown_checker.utils.extract_links import MarkdownLinks
 
+TLink = TypeVar("TLink", bound=MarkdownLinkBase, covariant=True)
 
-class BaseCheck(ABC):
+
+class BaseCheck(Generic[TLink], ABC):
     """Abstract base class for all link checks."""
 
     name: str
@@ -18,7 +22,7 @@ class BaseCheck(ABC):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
+    ) -> list[TLink]:
         """
         Run the check against the extracted links.
 

--- a/src/markdown_checker/checks/broken_paths.py
+++ b/src/markdown_checker/checks/broken_paths.py
@@ -1,10 +1,10 @@
 from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
-from markdown_checker.models import MarkdownLinkBase
+from markdown_checker.models import MarkdownPath
 from markdown_checker.utils.extract_links import MarkdownLinks
 
 
-class BrokenPathsCheck(BaseCheck):
+class BrokenPathsCheck(BaseCheck[MarkdownPath]):
     """Check for relative paths in markdown files that do not exist on disk."""
 
     name = "check_broken_paths"
@@ -14,8 +14,8 @@ class BrokenPathsCheck(BaseCheck):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
-        detected_issues: list[MarkdownLinkBase] = []
+    ) -> list[MarkdownPath]:
+        detected_issues: list[MarkdownPath] = []
         for path in links.paths:
             if not path.exists():
                 path.issue = "is broken"

--- a/src/markdown_checker/checks/broken_urls.py
+++ b/src/markdown_checker/checks/broken_urls.py
@@ -3,7 +3,6 @@ from functools import partial
 
 from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
-from markdown_checker.models import MarkdownLinkBase
 from markdown_checker.models import MarkdownURL
 from markdown_checker.utils.extract_links import MarkdownLinks
 
@@ -25,23 +24,33 @@ def _check_url(
 ) -> MarkdownURL | None:
     """Thread worker: checks a single URL with its own httpx2 client."""
     hostname = url.host_name().lower()
-    if any(domain.lower() in hostname for domain in skip_domains) or any(
+    if any(domain in hostname for domain in skip_domains) or any(
         substring in url.link for substring in skip_urls_containing
     ):
         return None
-    # Each worker creates its own client via is_alive(client=None).
-    if not url.is_alive(
+    # Each worker creates its own client via check(client=None).
+    result = url.check(
         timeout=timeout,
         retries=retries,
         retry_on_429=retry_on_429,
         fallback_retry_delay=fallback_retry_delay,
-    ):
+    )
+    if result.status == "alive":
+        return None
+    if result.status == "broken":
         url.issue = "is broken"
+        url.issue_level = "error"
         return url
-    return None
+    if result.status == "rate_limited":
+        url.issue = "was skipped due to rate limiting"
+    else:
+        # transient_error
+        url.issue = "could not be reached due to a network error"
+    url.issue_level = "warning"
+    return url
 
 
-class BrokenURLsCheck(BaseCheck):
+class BrokenURLsCheck(BaseCheck[MarkdownURL]):
     """Check for URLs in markdown files that return non-2xx responses."""
 
     name = "check_broken_urls"
@@ -51,9 +60,9 @@ class BrokenURLsCheck(BaseCheck):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
+    ) -> list[MarkdownURL]:
         config = config or Config()
-        effective_skip = [*config.skip_domains, *_BUILTIN_SKIP_DOMAINS]
+        effective_skip = [domain.lower() for domain in [*config.skip_domains, *_BUILTIN_SKIP_DOMAINS]]
         skip_urls_containing = config.skip_urls_containing
 
         worker = partial(
@@ -67,12 +76,9 @@ class BrokenURLsCheck(BaseCheck):
         )
         # NOTE: httpx2.Client is NOT thread-safe. Do not share a single client
         # across ThreadPoolExecutor workers. Each worker creates its own
-        # client via is_alive(client=None) to avoid RuntimeError crashes.
+        # client via check(client=None) to avoid RuntimeError crashes.
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = {executor.submit(worker, url): url for url in links.urls}
-            results: list[MarkdownLinkBase] = []
-            for future in concurrent.futures.as_completed(futures):
-                result = future.result()
-                if result is not None:
-                    results.append(result)
+            results: list[MarkdownURL] = [
+                outcome for outcome in executor.map(worker, links.urls) if outcome is not None
+            ]
         return results

--- a/src/markdown_checker/checks/broken_urls.py
+++ b/src/markdown_checker/checks/broken_urls.py
@@ -43,6 +43,8 @@ def _check_url(
         return url
     if result.status == "rate_limited":
         url.issue = "was skipped due to rate limiting"
+    elif result.status == "unverifiable":
+        url.issue = "could not be verified (access was forbidden by the server)"
     else:
         # transient_error
         url.issue = "could not be reached due to a network error"

--- a/src/markdown_checker/checks/locale.py
+++ b/src/markdown_checker/checks/locale.py
@@ -1,6 +1,6 @@
 from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
-from markdown_checker.models import MarkdownLinkBase
+from markdown_checker.models import MarkdownURL
 from markdown_checker.utils.extract_links import MarkdownLinks
 
 # Domains where locale is required in the URL path; always skipped for locale checks.
@@ -9,7 +9,7 @@ _BUILTIN_SKIP_DOMAINS: list[str] = [
 ]
 
 
-class URLsLocaleCheck(BaseCheck):
+class URLsLocaleCheck(BaseCheck[MarkdownURL]):
     """Check that URLs do not contain a country/language locale segment."""
 
     name = "check_urls_locale"
@@ -19,12 +19,12 @@ class URLsLocaleCheck(BaseCheck):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
+    ) -> list[MarkdownURL]:
         config = config or Config()
         effective_skip = [*config.skip_domains, *_BUILTIN_SKIP_DOMAINS]
         skip_urls_containing = config.skip_urls_containing
 
-        detected_issues: list[MarkdownLinkBase] = []
+        detected_issues: list[MarkdownURL] = []
         for url in links.urls:
             hostname = url.host_name().lower()
             if any(domain.lower() in hostname for domain in effective_skip) or any(

--- a/src/markdown_checker/checks/tracking.py
+++ b/src/markdown_checker/checks/tracking.py
@@ -1,10 +1,11 @@
 from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
-from markdown_checker.models import MarkdownLinkBase
+from markdown_checker.models import MarkdownPath
+from markdown_checker.models import MarkdownURL
 from markdown_checker.utils.extract_links import MarkdownLinks
 
 
-class URLsTrackingCheck(BaseCheck):
+class URLsTrackingCheck(BaseCheck[MarkdownURL]):
     """Check that URLs on configured tracking domains include a tracking ID."""
 
     name = "check_urls_tracking"
@@ -14,13 +15,13 @@ class URLsTrackingCheck(BaseCheck):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
+    ) -> list[MarkdownURL]:
         config = config or Config()
         skip_domains = config.skip_domains
         skip_urls_containing = config.skip_urls_containing
         tracking_domains = config.tracking_domains
 
-        detected_issues: list[MarkdownLinkBase] = []
+        detected_issues: list[MarkdownURL] = []
         for url in links.urls:
             hostname = url.host_name().lower()
             if any(domain.lower() in hostname for domain in skip_domains) or any(
@@ -33,7 +34,7 @@ class URLsTrackingCheck(BaseCheck):
         return detected_issues
 
 
-class PathsTrackingCheck(BaseCheck):
+class PathsTrackingCheck(BaseCheck[MarkdownPath]):
     """Check that relative paths include a tracking ID."""
 
     name = "check_paths_tracking"
@@ -43,8 +44,8 @@ class PathsTrackingCheck(BaseCheck):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownLinkBase]:
-        detected_issues: list[MarkdownLinkBase] = []
+    ) -> list[MarkdownPath]:
+        detected_issues: list[MarkdownPath] = []
         for path in links.paths:
             if not path.has_tracking():
                 path.issue = "is missing tracking id"

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -215,34 +215,57 @@ def main(
     )
 
     if check_result.issues:
-        formatted_output = format_issues_table(check_result.issues, config.output_mode)
-        generator = MarkdownGenerator(contributing_guide_url=guide_url, output_file_name=output_file_name)
-        generator.generate(func, formatted_output)
+        error_by_file = []
+        rendered_issues = []
+        error_count = 0
+        warning_count = 0
 
-        all_issues = [issue for _, issues in check_result.issues for issue in issues]
-        click.echo(click.style(f"😭 Found {len(all_issues)} issues in the following files:", fg="red"), err=True)
-        for markdown_path in all_issues:
-            if config.output_mode == "ci":
-                # Ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message
-                click.echo(
-                    click.style(
-                        f"::error file={markdown_path.file_path},line={markdown_path.line_number}::"
-                        f"File {markdown_path.file_path}, line {markdown_path.line_number}, "
-                        f"Link {markdown_path} {markdown_path.issue}.",
-                        fg="red",
-                    ),
-                    err=True,
-                )
-            else:
-                click.echo(
-                    click.style(
-                        f"\tFile '{markdown_path.file_path.resolve()}', line {markdown_path.line_number}"
-                        f"\n{markdown_path} {markdown_path.issue}.\n",
-                        fg="red",
-                    ),
-                    err=True,
-                )
-        ctx.exit(1)
+        for path, issues in check_result.issues:
+            file_errors = []
+            resolved_path = path.resolve() if config.output_mode == "local" else None
+            for issue in issues:
+                is_warning = issue.issue_level == "warning"
+                if issue.issue_level == "error":
+                    error_count += 1
+                    file_errors.append(issue)
+                else:
+                    warning_count += 1
+                if config.output_mode == "ci":
+                    level = "warning" if is_warning else "error"
+                    rendered_issues.append(
+                        (
+                            f"::{level} file={issue.file_path},line={issue.line_number}::"
+                            f"File {issue.file_path}, line {issue.line_number}, "
+                            f"Link {issue} {issue.issue}.",
+                            "yellow" if is_warning else "red",
+                        )
+                    )
+                else:
+                    rendered_issues.append(
+                        (
+                            f"\tFile '{resolved_path}', line {issue.line_number}\n{issue} {issue.issue}.\n",
+                            "yellow" if is_warning else "red",
+                        )
+                    )
+            if file_errors:
+                error_by_file.append((path, file_errors))
+
+        if error_count:
+            formatted_output = format_issues_table(error_by_file, config.output_mode)
+            generator = MarkdownGenerator(contributing_guide_url=guide_url, output_file_name=output_file_name)
+            generator.generate(func, formatted_output)
+            click.echo(click.style(f"😭 Found {error_count} issues in the following files:", fg="red"), err=True)
+
+        if warning_count:
+            click.echo(
+                click.style(f"⚠ {warning_count} links had warnings:", fg="yellow"),
+                err=True,
+            )
+
+        for message, color in rendered_issues:
+            click.echo(click.style(message, fg=color), err=True)
+
+        ctx.exit(1 if error_count else 0)
 
     click.echo(click.style("All files are compliant with the guidelines. 🎉", fg="green"), err=False)
     ctx.exit(0)

--- a/src/markdown_checker/models/__init__.py
+++ b/src/markdown_checker/models/__init__.py
@@ -4,5 +4,14 @@ from markdown_checker.models.config import create_http_client
 from markdown_checker.models.config import DEFAULT_HEADERS
 from markdown_checker.models.path import MarkdownPath
 from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
 
-__all__ = ["Config", "DEFAULT_HEADERS", "create_http_client", "MarkdownLinkBase", "MarkdownPath", "MarkdownURL"]
+__all__ = [
+    "Config",
+    "DEFAULT_HEADERS",
+    "create_http_client",
+    "MarkdownLinkBase",
+    "MarkdownPath",
+    "MarkdownURL",
+    "URLCheckResult",
+]

--- a/src/markdown_checker/models/base.py
+++ b/src/markdown_checker/models/base.py
@@ -2,6 +2,7 @@ import re
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 _LOCALE_PATTERN = re.compile(r"\/[a-z]{2}-[a-z]{2}\/")
 _TRACKING_PATTERN = re.compile(r"(\?|\&)(WT|wt)\.mc_id=")
@@ -15,6 +16,7 @@ class MarkdownLinkBase(ABC):
     line_number: int
     file_path: Path
     issue: str = ""
+    issue_level: Literal["error", "warning"] = "error"
 
     def has_locale(self) -> bool:
         """

--- a/src/markdown_checker/models/url.py
+++ b/src/markdown_checker/models/url.py
@@ -17,7 +17,7 @@ from markdown_checker.models.config import create_http_client
 class URLCheckResult:
     """Typed outcome of checking whether a URL is reachable."""
 
-    status: Literal["alive", "broken", "rate_limited", "transient_error"]
+    status: Literal["alive", "broken", "rate_limited", "transient_error", "unverifiable"]
     http_status_code: int | None = None
     retry_after: int | None = None
 
@@ -99,6 +99,7 @@ class MarkdownURL(MarkdownLinkBase):
         last_retry_after: int | None = None
         saw_hard_failure = False
         saw_rate_limit = False
+        saw_auth_error = False
         try:
             for attempt in range(retries):
                 sleep_override: float | None = None
@@ -113,7 +114,7 @@ class MarkdownURL(MarkdownLinkBase):
                         saw_rate_limit = True
                         last_retry_after = int(sleep_override)
                     else:
-                        saw_hard_failure = True
+                        # Fall back to GET — some servers reject HEAD but allow GET.
                         response = _client.get(self.link, timeout=timeout)
                         last_status_code = response.status_code
                         if response.is_success:
@@ -123,6 +124,10 @@ class MarkdownURL(MarkdownLinkBase):
                         if sleep_override is not None:
                             saw_rate_limit = True
                             last_retry_after = int(sleep_override)
+                        elif response.status_code in (401, 403):
+                            # 401/403 means the server exists but is blocking automated access.
+                            # We cannot determine the real status of the resource.
+                            saw_auth_error = True
                         else:
                             saw_hard_failure = True
                 except httpx2.UnsupportedProtocol:
@@ -145,4 +150,6 @@ class MarkdownURL(MarkdownLinkBase):
             return URLCheckResult(
                 status="rate_limited", http_status_code=last_status_code, retry_after=last_retry_after
             )
+        if saw_auth_error:
+            return URLCheckResult(status="unverifiable", http_status_code=last_status_code)
         return URLCheckResult(status="transient_error", http_status_code=None)

--- a/src/markdown_checker/models/url.py
+++ b/src/markdown_checker/models/url.py
@@ -3,6 +3,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
+from typing import Literal
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
 
@@ -10,6 +11,15 @@ import httpx2
 
 from markdown_checker.models.base import MarkdownLinkBase
 from markdown_checker.models.config import create_http_client
+
+
+@dataclass(slots=True)
+class URLCheckResult:
+    """Typed outcome of checking whether a URL is reachable."""
+
+    status: Literal["alive", "broken", "rate_limited", "transient_error"]
+    http_status_code: int | None = None
+    retry_after: int | None = None
 
 
 def _retry_after_delay(response: httpx2.Response, fallback: int) -> float | None:
@@ -32,9 +42,9 @@ def _retry_after_delay(response: httpx2.Response, fallback: int) -> float | None
             pass
         # Try HTTP-date format (e.g. "Wed, 21 Oct 2015 07:28:00 GMT").
         try:
-            dt = email.utils.parsedate_to_datetime(header)
-            now = datetime.now(timezone.utc)
-            delay = (dt - now).total_seconds()
+            dt: datetime = email.utils.parsedate_to_datetime(header)
+            now: datetime = datetime.now(timezone.utc)
+            delay: float = (dt - now).total_seconds()
             return max(0.0, delay)
         except Exception:
             pass
@@ -62,16 +72,16 @@ class MarkdownURL(MarkdownLinkBase):
         """
         return self.parsed_url.netloc
 
-    def is_alive(
+    def check(
         self,
         timeout: int = 20,
         retries: int = 3,
         client: httpx2.Client | None = None,
         retry_on_429: bool = True,
         fallback_retry_delay: int = 30,
-    ) -> bool:
+    ) -> URLCheckResult:
         """
-        Check if the URL is alive
+        Check whether the URL is reachable and return a typed outcome.
 
         Args:
             timeout (int): Timeout for the request in seconds.
@@ -81,28 +91,44 @@ class MarkdownURL(MarkdownLinkBase):
             fallback_retry_delay (int): Seconds to wait when a 429 carries no Retry-After header.
 
         Returns:
-            bool: True if the URL is alive, False otherwise
+            URLCheckResult with status one of: ``alive``, ``broken``,
+            ``rate_limited``, or ``transient_error``.
         """
         _client = client or create_http_client()
+        last_status_code: int | None = None
+        last_retry_after: int | None = None
+        saw_hard_failure = False
+        saw_rate_limit = False
         try:
             for attempt in range(retries):
                 sleep_override: float | None = None
                 try:
                     response = _client.head(self.link, timeout=timeout)
+                    last_status_code = response.status_code
                     if response.is_success:
-                        return True
+                        return URLCheckResult(status="alive", http_status_code=response.status_code)
                     if retry_on_429:
                         sleep_override = _retry_after_delay(response, fallback_retry_delay)
-                    if sleep_override is None:
+                    if sleep_override is not None:
+                        saw_rate_limit = True
+                        last_retry_after = int(sleep_override)
+                    else:
+                        saw_hard_failure = True
                         response = _client.get(self.link, timeout=timeout)
+                        last_status_code = response.status_code
                         if response.is_success:
-                            return True
+                            return URLCheckResult(status="alive", http_status_code=response.status_code)
                         if retry_on_429:
                             sleep_override = _retry_after_delay(response, fallback_retry_delay)
+                        if sleep_override is not None:
+                            saw_rate_limit = True
+                            last_retry_after = int(sleep_override)
+                        else:
+                            saw_hard_failure = True
                 except httpx2.UnsupportedProtocol:
                     # Server redirected to a non-HTTP scheme (e.g. vscode://).
                     # The original URL is reachable; treat it as alive.
-                    return True
+                    return URLCheckResult(status="alive", http_status_code=None)
                 except (httpx2.HTTPError, RuntimeError):
                     pass
                 if attempt < retries - 1:
@@ -113,4 +139,10 @@ class MarkdownURL(MarkdownLinkBase):
         finally:
             if client is None:
                 _client.close()
-        return False
+        if saw_hard_failure:
+            return URLCheckResult(status="broken", http_status_code=last_status_code)
+        if saw_rate_limit:
+            return URLCheckResult(
+                status="rate_limited", http_status_code=last_status_code, retry_after=last_retry_after
+            )
+        return URLCheckResult(status="transient_error", http_status_code=None)

--- a/tests/test_checks_broken_urls.py
+++ b/tests/test_checks_broken_urls.py
@@ -8,6 +8,7 @@ from markdown_checker.checks.broken_urls import _check_url
 from markdown_checker.checks.broken_urls import BrokenURLsCheck
 from markdown_checker.models.config import Config
 from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
 
 
 @pytest.fixture
@@ -31,10 +32,11 @@ def test_alive_url_not_reported(check, make_markdown_url, make_markdown_links):
     """Alive URLs are not reported."""
     url = make_markdown_url("https://example.com")
     links = make_markdown_links(urls=[url])
-    with patch.object(MarkdownURL, "is_alive", return_value=True):
+    alive_result = URLCheckResult(status="alive", http_status_code=200)
+    with patch.object(MarkdownURL, "check", return_value=alive_result):
         result = check.run(links, config=Config(skip_domains=list(_BUILTIN_SKIP_DOMAINS)))
     # example.com not in builtin skip, so it gets checked
-    # Since we mock is_alive to True, nothing should be returned
+    # Since we mock check to return alive, nothing should be returned
     assert result == []
 
 
@@ -42,7 +44,8 @@ def test_dead_url_reported(check, make_markdown_url, make_markdown_links):
     """Dead URLs are reported with 'is broken' issue."""
     url = make_markdown_url("https://totally-fake-domain-12345.com/page")
     links = make_markdown_links(urls=[url])
-    with patch.object(MarkdownURL, "is_alive", return_value=False):
+    broken_result = URLCheckResult(status="broken", http_status_code=404)
+    with patch.object(MarkdownURL, "check", return_value=broken_result):
         result = check.run(links)
     assert len(result) == 1
     assert result[0].issue == "is broken"
@@ -52,9 +55,9 @@ def test_builtin_skip_domains_skipped(check, make_markdown_url, make_markdown_li
     """URLs from builtin skip domains are not checked."""
     url = make_markdown_url("https://openai.com/pricing")
     links = make_markdown_links(urls=[url])
-    with patch.object(MarkdownURL, "is_alive") as mock_alive:
+    with patch.object(MarkdownURL, "check") as mock_check:
         result = check.run(links)
-    mock_alive.assert_not_called()
+    mock_check.assert_not_called()
     assert result == []
 
 
@@ -62,9 +65,9 @@ def test_custom_skip_domains(check, make_markdown_url, make_markdown_links):
     """Custom skip domains are respected."""
     url = make_markdown_url("https://custom-skip.com/page")
     links = make_markdown_links(urls=[url])
-    with patch.object(MarkdownURL, "is_alive") as mock_alive:
+    with patch.object(MarkdownURL, "check") as mock_check:
         result = check.run(links, config=Config(skip_domains=["custom-skip.com"]))
-    mock_alive.assert_not_called()
+    mock_check.assert_not_called()
     assert result == []
 
 
@@ -72,9 +75,9 @@ def test_skip_urls_containing(check, make_markdown_url, make_markdown_links):
     """URLs containing skip substrings are not checked."""
     url = make_markdown_url("https://example.com/video-embed.html")
     links = make_markdown_links(urls=[url])
-    with patch.object(MarkdownURL, "is_alive") as mock_alive:
+    with patch.object(MarkdownURL, "check") as mock_check:
         check.run(links, config=Config(skip_urls_containing=["https://example.com/video-embed.html"]))
-    mock_alive.assert_not_called()
+    mock_check.assert_not_called()
 
 
 # --- Tests for _check_url helper ---
@@ -98,7 +101,8 @@ def test_check_url_returns_none_for_skipped_domain():
 def test_check_url_returns_url_for_broken():
     """Returns the URL with issue set when it is not alive."""
     url = MarkdownURL(link="https://broken.example.com", line_number=1, file_path=Path("test.md"))
-    with patch.object(MarkdownURL, "is_alive", return_value=False):
+    broken_result = URLCheckResult(status="broken", http_status_code=404)
+    with patch.object(MarkdownURL, "check", return_value=broken_result):
         result = _check_url(
             url,
             skip_domains=[],
@@ -110,12 +114,14 @@ def test_check_url_returns_url_for_broken():
         )
     assert result is not None
     assert result.issue == "is broken"
+    assert result.issue_level == "error"
 
 
 def test_check_url_returns_none_for_alive():
     """Returns None for alive URLs."""
     url = MarkdownURL(link="https://alive.example.com", line_number=1, file_path=Path("test.md"))
-    with patch.object(MarkdownURL, "is_alive", return_value=True):
+    alive_result = URLCheckResult(status="alive", http_status_code=200)
+    with patch.object(MarkdownURL, "check", return_value=alive_result):
         result = _check_url(
             url,
             skip_domains=[],
@@ -133,3 +139,91 @@ def test_builtin_skip_domains_list():
     assert isinstance(_BUILTIN_SKIP_DOMAINS, list)
     assert len(_BUILTIN_SKIP_DOMAINS) > 0
     assert "openai.com" in _BUILTIN_SKIP_DOMAINS
+
+
+# --- Rate-limiting tests ---
+
+
+def test_check_url_rate_limited_returns_warning_issue():
+    """rate_limited status: URL is returned with issue_level='warning' and issue set."""
+    url = MarkdownURL(link="https://rate-limited.example.com", line_number=1, file_path=Path("test.md"))
+    rate_limited_result = URLCheckResult(status="rate_limited", http_status_code=429, retry_after=30)
+    with patch.object(MarkdownURL, "check", return_value=rate_limited_result):
+        result = _check_url(
+            url,
+            skip_domains=[],
+            skip_urls_containing=[],
+            timeout=5,
+            retries=1,
+            retry_on_429=True,
+            fallback_retry_delay=30,
+        )
+    assert result is not None
+    assert result.issue == "was skipped due to rate limiting"
+    assert result.issue_level == "warning"
+
+
+def test_check_url_transient_error_returns_warning_issue():
+    """transient_error status: URL is returned with issue_level='warning' and issue set."""
+    url = MarkdownURL(link="https://flaky.example.com", line_number=1, file_path=Path("test.md"))
+    transient_result = URLCheckResult(status="transient_error", http_status_code=None)
+    with patch.object(MarkdownURL, "check", return_value=transient_result):
+        result = _check_url(
+            url,
+            skip_domains=[],
+            skip_urls_containing=[],
+            timeout=5,
+            retries=1,
+            retry_on_429=True,
+            fallback_retry_delay=30,
+        )
+    assert result is not None
+    assert result.issue == "could not be reached due to a network error"
+    assert result.issue_level == "warning"
+
+
+def test_rate_limited_urls_reported_as_warnings(check, make_markdown_url, make_markdown_links):
+    """URLs that return rate_limited are in the results list with issue_level='warning'."""
+    url = make_markdown_url("https://rate-limited.example.com")
+    links = make_markdown_links(urls=[url])
+    rate_limited_result = URLCheckResult(status="rate_limited", http_status_code=429, retry_after=60)
+    with patch.object(MarkdownURL, "check", return_value=rate_limited_result):
+        result = check.run(links)
+    assert len(result) == 1
+    assert result[0].issue_level == "warning"
+    assert result[0].issue == "was skipped due to rate limiting"
+
+
+def test_rate_limited_count_across_urls(check, make_markdown_url, make_markdown_links):
+    """All rate-limited URLs are included in the results as warnings."""
+    urls = [make_markdown_url(f"https://example.com/{i}") for i in range(3)]
+    links = make_markdown_links(urls=urls)
+    rate_limited_result = URLCheckResult(status="rate_limited", http_status_code=429)
+    with patch.object(MarkdownURL, "check", return_value=rate_limited_result):
+        result = check.run(links)
+    assert len(result) == 3
+    assert all(r.issue_level == "warning" for r in result)
+
+
+def test_mixed_outcomes_broken_error_rate_limited_warning(check, make_markdown_url, make_markdown_links):
+    """Broken URLs have issue_level='error'; rate-limited have 'warning'; alive are excluded."""
+    url_broken = make_markdown_url("https://broken.example.com")
+    url_rate_limited = make_markdown_url("https://rate-limited.example.com")
+    url_alive = make_markdown_url("https://alive.example.com")
+    links = make_markdown_links(urls=[url_broken, url_rate_limited, url_alive])
+
+    def fake_check(self, **kwargs):
+        if "broken" in self.link:
+            return URLCheckResult(status="broken", http_status_code=404)
+        if "rate-limited" in self.link:
+            return URLCheckResult(status="rate_limited", http_status_code=429)
+        return URLCheckResult(status="alive", http_status_code=200)
+
+    with patch.object(MarkdownURL, "check", fake_check):
+        result = check.run(links)
+
+    assert len(result) == 2
+    broken = next(r for r in result if "broken" in r.link)
+    rate_limited = next(r for r in result if "rate-limited" in r.link)
+    assert broken.issue_level == "error"
+    assert rate_limited.issue_level == "warning"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,14 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import click
 import pytest
 from click.testing import CliRunner
 
+from markdown_checker.checker import CheckResult
 from markdown_checker.cli import ListOfStrings
 from markdown_checker.cli import main
+from markdown_checker.models.url import MarkdownURL
 
 
 @pytest.fixture
@@ -153,6 +156,90 @@ def test_cli_ci_mode(runner, resources_dir, monkeypatch, tmp_path):
         ["-d", str(resources_dir), "-f", "check_broken_paths", "-o", str(tmp_path / "ci_output")],
     )
     assert result.exit_code == 0
+
+
+def test_cli_warning_only_run_does_not_print_compliant_message(runner, tmp_path, monkeypatch):
+    """Warning-only runs exit successfully without claiming all files are compliant."""
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Sample\n")
+    warning_issue = MarkdownURL(
+        link="https://example.com",
+        line_number=1,
+        file_path=sample,
+        issue="was skipped due to rate limiting",
+        issue_level="warning",
+    )
+    check_result = CheckResult(issues=[(sample, [warning_issue])], links_checked=1)
+
+    with (
+        patch("markdown_checker.cli.run_check_on_files", return_value=check_result),
+        patch("markdown_checker.cli.MarkdownGenerator.generate") as mock_generate,
+    ):
+        result = runner.invoke(main, [str(sample), "-f", "check_broken_urls"])
+
+    assert result.exit_code == 0
+    assert "links had warnings" in result.output
+    assert "All files are compliant" not in result.output
+    mock_generate.assert_not_called()
+
+
+def test_cli_local_issues_prints_all_issues_before_exiting(runner, tmp_path):
+    """Local mode prints every issue before exiting with an error."""
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Sample\n")
+    error_issue = MarkdownURL(
+        link="https://broken.example.com",
+        line_number=1,
+        file_path=sample,
+        issue="is broken",
+        issue_level="error",
+    )
+    warning_issue = MarkdownURL(
+        link="https://rate-limited.example.com",
+        line_number=2,
+        file_path=sample,
+        issue="was skipped due to rate limiting",
+        issue_level="warning",
+    )
+    check_result = CheckResult(issues=[(sample, [error_issue, warning_issue])], links_checked=2)
+
+    with (
+        patch("markdown_checker.cli.run_check_on_files", return_value=check_result),
+        patch("markdown_checker.cli.MarkdownGenerator.generate") as mock_generate,
+    ):
+        result = runner.invoke(main, [str(sample), "-f", "check_broken_urls"])
+
+    assert result.exit_code == 1
+    assert "https://broken.example.com is broken." in result.output
+    assert "https://rate-limited.example.com was skipped due to rate limiting." in result.output
+    assert "All files are compliant" not in result.output
+    mock_generate.assert_called_once()
+
+
+def test_cli_ci_issues_do_not_fall_through_to_success(runner, tmp_path, monkeypatch):
+    """CI mode emits annotations and does not print the success message when issues exist."""
+    monkeypatch.setenv("CI", "true")
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Sample\n")
+    error_issue = MarkdownURL(
+        link="https://broken.example.com",
+        line_number=1,
+        file_path=sample,
+        issue="is broken",
+        issue_level="error",
+    )
+    check_result = CheckResult(issues=[(sample, [error_issue])], links_checked=1)
+
+    with (
+        patch("markdown_checker.cli.run_check_on_files", return_value=check_result),
+        patch("markdown_checker.cli.MarkdownGenerator.generate") as mock_generate,
+    ):
+        result = runner.invoke(main, [str(sample), "-f", "check_broken_urls"])
+
+    assert result.exit_code == 1
+    assert "::error file=" in result.output
+    assert "All files are compliant" not in result.output
+    mock_generate.assert_called_once()
 
 
 # --- SRC positional argument ---

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -65,3 +65,15 @@ def test_issue_can_be_set():
     """Issue field can be set on construction."""
     obj = MarkdownPath(link="./docs/guide.md", line_number=1, file_path=Path("test.md"), issue="is broken")
     assert obj.issue == "is broken"
+
+
+def test_issue_level_defaults_to_error():
+    """issue_level defaults to 'error'."""
+    obj = MarkdownPath(link="./docs/guide.md", line_number=1, file_path=Path("test.md"))
+    assert obj.issue_level == "error"
+
+
+def test_issue_level_can_be_set_to_warning():
+    """issue_level can be explicitly set to 'warning'."""
+    obj = MarkdownPath(link="./docs/guide.md", line_number=1, file_path=Path("test.md"), issue_level="warning")
+    assert obj.issue_level == "warning"

--- a/tests/test_models_url.py
+++ b/tests/test_models_url.py
@@ -316,3 +316,47 @@ def test_check_returns_transient_error_on_network_failure():
         result = url.check(timeout=5, retries=2, client=mock_client)
     assert result.status == "transient_error"
     assert result.http_status_code is None
+
+
+def test_check_returns_unverifiable_when_head_and_get_both_return_403():
+    """check() returns status='unverifiable' when both HEAD and GET return 403."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.return_value = _make_response(403)
+    mock_client.get.return_value = _make_response(403)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "unverifiable"
+    assert result.http_status_code == 403
+
+
+def test_check_returns_unverifiable_when_head_and_get_both_return_401():
+    """check() returns status='unverifiable' when both HEAD and GET return 401."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.return_value = _make_response(401)
+    mock_client.get.return_value = _make_response(401)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "unverifiable"
+    assert result.http_status_code == 401
+
+
+def test_check_returns_alive_when_head_returns_403_but_get_succeeds():
+    """check() falls back to GET and returns alive when HEAD is 403 but GET succeeds."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.return_value = _make_response(403)
+    mock_client.get.return_value = _make_response(200)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "alive"
+    assert result.http_status_code == 200
+
+
+def test_check_returns_broken_when_head_returns_403_but_get_returns_404():
+    """check() returns broken when HEAD is 403 but GET reveals the resource is gone (404)."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.return_value = _make_response(403)
+    mock_client.get.return_value = _make_response(404)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "broken"
+    assert result.http_status_code == 404

--- a/tests/test_models_url.py
+++ b/tests/test_models_url.py
@@ -6,6 +6,7 @@ import httpx2
 import pytest
 
 from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
 
 
 @pytest.mark.parametrize(
@@ -34,69 +35,65 @@ def test_parsed_url_returns_parse_result():
     assert parsed.fragment == "frag"
 
 
-def test_is_alive_success():
-    """Returns True when HEAD request succeeds."""
+def test_check_success():
+    """Returns alive when HEAD request succeeds."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    mock_response = MagicMock()
-    mock_response.is_success = True
     mock_client = MagicMock(spec=httpx2.Client)
-    mock_client.head.return_value = mock_response
-    assert url.is_alive(timeout=5, retries=1, client=mock_client) is True
+    mock_client.head.return_value = _make_response(200)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "alive"
 
 
-def test_is_alive_head_fails_get_succeeds():
+def test_check_head_fails_get_succeeds():
     """Falls back to GET when HEAD fails."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    head_response = MagicMock()
-    head_response.is_success = False
-    get_response = MagicMock()
-    get_response.is_success = True
     mock_client = MagicMock(spec=httpx2.Client)
-    mock_client.head.return_value = head_response
-    mock_client.get.return_value = get_response
-    assert url.is_alive(timeout=5, retries=1, client=mock_client) is True
+    mock_client.head.return_value = _make_response(404)
+    mock_client.get.return_value = _make_response(200)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "alive"
 
 
-def test_is_alive_all_fail():
-    """Returns False when both HEAD and GET fail for all retries."""
+def test_check_all_fail():
+    """Returns broken when both HEAD and GET fail for all retries."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    head_response = MagicMock()
-    head_response.is_success = False
-    get_response = MagicMock()
-    get_response.is_success = False
     mock_client = MagicMock(spec=httpx2.Client)
-    mock_client.head.return_value = head_response
-    mock_client.get.return_value = get_response
-    assert url.is_alive(timeout=5, retries=1, client=mock_client) is False
+    mock_client.head.return_value = _make_response(404)
+    mock_client.get.return_value = _make_response(404)
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "broken"
 
 
-def test_is_alive_http_error_retries():
-    """Retries on httpx2.HTTPError and returns False after exhausting retries."""
+def test_check_http_error_retries():
+    """Retries on httpx2.HTTPError and returns transient_error after exhausting retries."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
     mock_client.head.side_effect = httpx2.HTTPError("timeout")
     with patch("markdown_checker.models.url.time.sleep"):
-        assert url.is_alive(timeout=5, retries=2, client=mock_client) is False
+        result = url.check(timeout=5, retries=2, client=mock_client)
+    assert result.status == "transient_error"
     assert mock_client.head.call_count == 2
 
 
-def test_is_alive_unsupported_protocol_redirect():
-    """Returns True when redirect leads to a non-HTTP scheme (e.g. vscode://)."""
+def test_check_unsupported_protocol_redirect():
+    """Returns alive when redirect leads to a non-HTTP scheme (e.g. vscode://)."""
     url = MarkdownURL(
         link="https://vscode.dev/redirect?url=vscode://something", line_number=1, file_path=Path("test.md")
     )
     mock_client = MagicMock(spec=httpx2.Client)
     mock_client.head.side_effect = httpx2.UnsupportedProtocol("Request URL has an unsupported protocol 'vscode://'.")
-    assert url.is_alive(timeout=5, retries=1, client=mock_client) is True
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "alive"
 
 
-def test_is_alive_runtime_error_returns_false():
-    """Returns False when client raises RuntimeError (e.g. client closed)."""
+def test_check_runtime_error_returns_transient_error():
+    """Returns transient_error when client raises RuntimeError (e.g. client closed)."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
     mock_client.head.side_effect = RuntimeError("Cannot send a request, as the client has been closed.")
     with patch("markdown_checker.models.url.time.sleep"):
-        assert url.is_alive(timeout=5, retries=2, client=mock_client) is False
+        result = url.check(timeout=5, retries=2, client=mock_client)
+    assert result.status == "transient_error"
     assert mock_client.head.call_count == 2
 
 
@@ -110,24 +107,23 @@ def _make_response(status_code: int, headers: dict | None = None) -> MagicMock:
     return resp
 
 
-def test_is_alive_429_with_retry_after_integer_sleeps_and_retries():
-    """429 + Retry-After: 2 → sleep(2) called, request retried, returns True on success."""
+def test_check_429_with_retry_after_integer_sleeps_and_retries():
+    """429 + Retry-After: 2 → sleep(2) called, request retried, returns alive on success."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
     rate_limited = _make_response(429, {"retry-after": "2"})
     success = _make_response(200)
-    success.is_success = True
     mock_client.head.side_effect = [rate_limited, success]
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
 
-    assert result is True
+    assert result.status == "alive"
     mock_sleep.assert_called_once_with(2.0)
     assert mock_client.head.call_count == 2
 
 
-def test_is_alive_429_without_retry_after_uses_fallback():
+def test_check_429_without_retry_after_uses_fallback():
     """429 with no Retry-After header → sleep(fallback_retry_delay) called."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
@@ -136,14 +132,14 @@ def test_is_alive_429_without_retry_after_uses_fallback():
     mock_client.head.side_effect = [rate_limited, success]
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
 
-    assert result is True
+    assert result.status == "alive"
     mock_sleep.assert_called_once_with(30.0)
 
 
-def test_is_alive_429_retry_succeeds_no_issue():
-    """After a 429, a successful retry means is_alive returns True (no issue set)."""
+def test_check_429_retry_succeeds():
+    """After a 429, a successful retry means check returns alive."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
     rate_limited = _make_response(429, {"retry-after": "1"})
@@ -151,10 +147,9 @@ def test_is_alive_429_retry_succeeds_no_issue():
     mock_client.head.side_effect = [rate_limited, success]
 
     with patch("markdown_checker.models.url.time.sleep"):
-        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
 
-    assert result is True
-    assert url.issue == ""
+    assert result.status == "alive"
 
 
 def test_is_alive_retry_on_429_disabled_uses_exponential_backoff():
@@ -168,13 +163,13 @@ def test_is_alive_retry_on_429_disabled_uses_exponential_backoff():
     mock_client.get.return_value = rate_limited_get
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=False, fallback_retry_delay=60)
+        url.check(timeout=5, retries=2, client=mock_client, retry_on_429=False, fallback_retry_delay=60)
 
     # Should use exponential backoff (0.5 * 2^0 = 0.5), NOT the Retry-After value.
     mock_sleep.assert_called_once_with(0.5)
 
 
-def test_is_alive_non_success_with_retry_after_header_uses_delay():
+def test_check_non_success_with_retry_after_header_uses_delay():
     """Any non-success, non-redirect response with Retry-After is respected."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
@@ -184,32 +179,140 @@ def test_is_alive_non_success_with_retry_after_header_uses_delay():
     mock_client.head.side_effect = [throttled, success]
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.is_alive(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
 
-    assert result is True
+    assert result.status == "alive"
     mock_sleep.assert_called_once_with(5.0)
 
 
-def test_is_alive_creates_client_when_none():
+def test_check_creates_client_when_none():
     """Creates and closes its own httpx2.Client when none is provided."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    mock_response = MagicMock()
-    mock_response.is_success = True
     with patch("markdown_checker.models.url.httpx2.Client") as MockClient:
         mock_client_instance = MagicMock()
-        mock_client_instance.head.return_value = mock_response
+        mock_client_instance.head.return_value = _make_response(200)
         MockClient.return_value = mock_client_instance
-        result = url.is_alive(timeout=5, retries=1)
-        assert result is True
+        result = url.check(timeout=5, retries=1)
+        assert result.status == "alive"
         mock_client_instance.close.assert_called_once()
 
 
-def test_is_alive_does_not_close_provided_client():
+def test_check_does_not_close_provided_client():
     """Does not close the client when one is provided externally."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    mock_response = MagicMock()
-    mock_response.is_success = True
     mock_client = MagicMock(spec=httpx2.Client)
-    mock_client.head.return_value = mock_response
-    url.is_alive(timeout=5, retries=1, client=mock_client)
+    mock_client.head.return_value = _make_response(200)
+    url.check(timeout=5, retries=1, client=mock_client)
     mock_client.close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# URLCheckResult dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_url_check_result_fields():
+    """URLCheckResult stores all three fields."""
+    r = URLCheckResult(status="alive", http_status_code=200, retry_after=None)
+    assert r.status == "alive"
+    assert r.http_status_code == 200
+    assert r.retry_after is None
+
+
+def test_url_check_result_defaults():
+    """http_status_code and retry_after default to None."""
+    r = URLCheckResult(status="broken")
+    assert r.http_status_code is None
+    assert r.retry_after is None
+
+
+# ---------------------------------------------------------------------------
+# check() method — four outcome values
+# ---------------------------------------------------------------------------
+
+
+def test_check_returns_alive_on_2xx():
+    """check() returns status='alive' when HEAD responds with 2xx."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    success = _make_response(200)
+    mock_client.head.return_value = success
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "alive"
+    assert result.http_status_code == 200
+
+
+def test_check_returns_broken_on_persistent_404():
+    """check() returns status='broken' when HEAD and GET both return 404."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    not_found = _make_response(404)
+    mock_client.head.return_value = not_found
+    mock_client.get.return_value = not_found
+    result = url.check(timeout=5, retries=1, client=mock_client)
+    assert result.status == "broken"
+    assert result.http_status_code == 404
+
+
+def test_check_returns_rate_limited_when_429_exhausts_retries():
+    """check() returns status='rate_limited' when 429 persists across all retries."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "5"})
+    mock_client.head.return_value = rate_limited
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+    assert result.status == "rate_limited"
+    assert result.http_status_code == 429
+    assert result.retry_after == 5
+
+
+def test_check_returns_broken_when_429_is_followed_by_404():
+    """A later hard HTTP failure should classify the URL as broken, not rate-limited."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "5"})
+    not_found = _make_response(404)
+    mock_client.head.side_effect = [rate_limited, not_found]
+    mock_client.get.return_value = not_found
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+    assert result.status == "broken"
+    assert result.http_status_code == 404
+
+
+def test_check_returns_broken_when_network_error_is_followed_by_404():
+    """A later hard HTTP failure should classify the URL as broken, not transient_error."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    not_found = _make_response(404)
+    mock_client.head.side_effect = [httpx2.HTTPError("timeout"), not_found]
+    mock_client.get.return_value = not_found
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.check(timeout=5, retries=2, client=mock_client)
+    assert result.status == "broken"
+    assert result.http_status_code == 404
+
+
+def test_check_prefers_rate_limited_when_retries_mix_429_and_network_errors():
+    """Mixed 429 and network failures without a hard HTTP failure classify as rate_limited."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    rate_limited = _make_response(429, {"retry-after": "5"})
+    mock_client.head.side_effect = [rate_limited, httpx2.HTTPError("timeout")]
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+    assert result.status == "rate_limited"
+    assert result.http_status_code == 429
+    assert result.retry_after == 5
+
+
+def test_check_returns_transient_error_on_network_failure():
+    """check() returns status='transient_error' when only HTTPErrors are raised."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.side_effect = httpx2.HTTPError("connection refused")
+    with patch("markdown_checker.models.url.time.sleep"):
+        result = url.check(timeout=5, retries=2, client=mock_client)
+    assert result.status == "transient_error"
+    assert result.http_status_code is None


### PR DESCRIPTION
- Replaces the binary alive/broken URL check with a four-state outcome: alive, broken, rate_limited, and transient_error.
- Rate-limiting and network failures are now surfaced as warnings rather than errors, so they no longer cause a non-zero exit code.
- The CLI separates error-level and warning-level issues in its output, printing yellow warnings after red errors and only generating the markdown report for broken links.
- CI mode emits appropriately levelled GitHub Actions annotations.
- Domain skip-list matching is now case-insensitive at build time rather than per-check,
- Thread pool uses executor.map for simpler result collection.

related #122 