### PR TITLE
feat: dedupe, pace, and cache url checks across files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - Improve regex for matching URLs and paths.
 - Drop support for Python 3.10.
 - No longer built in skipping of domains.
+- Dedupe URL checks across files instead of checking the same link repeatedly.
+- Add per-host request pacing and a circuit breaker for rate limiting.
+- Overlap file checks with an adaptive in-flight window.
 
 
 [v1.0.3] 28 May 2026

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -285,6 +285,57 @@ Usage examples
   # Short-form alias
   markdown-checker -d . -f check_broken_urls -frd 45
 
+``-mw``, ``--max-workers``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type
+  ``Click.IntRange``
+Description
+  Maximum number of concurrent URL-check workers.
+Default
+  ``10``, or the number of available CPUs when running in GitHub Actions
+  (``$GITHUB_ACTIONS=true``).
+Range
+  ``1`` or greater.
+Required
+  No.
+
+Usage examples
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  # Use a custom worker count
+  markdown-checker -d . -f check_broken_urls --max-workers=20
+
+  # Short-form alias
+  markdown-checker -d . -f check_broken_urls -mw 20
+
+``-phd``, ``--per-host-delay``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type
+  ``Click.FloatRange``
+Description
+  Minimum delay in seconds between requests to the same host.
+Default
+  ``0.5``
+Range
+  ``0.0-10.0``
+Required
+  No.
+
+Usage examples
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  # Use a custom per-host delay of 1 second
+  markdown-checker -d . -f check_broken_urls --per-host-delay=1.0
+
+  # Short-form alias
+  markdown-checker -d . -f check_broken_urls -phd 1.0
+
 ``-o``, ``--output-file-name``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -4,3 +4,4 @@ Main
 .. automodule:: markdown_checker
 	:members:
 	:undoc-members:
+	:noindex:

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -9,6 +9,14 @@ Base
 	:undoc-members:
 	:show-inheritance:
 
+Config
+------
+
+.. automodule:: markdown_checker.models.config
+	:members:
+	:undoc-members:
+	:show-inheritance:
+
 Path
 ----
 

--- a/docs/api/patterns.rst
+++ b/docs/api/patterns.rst
@@ -1,0 +1,7 @@
+Patterns
+========
+
+.. automodule:: markdown_checker.patterns
+	:members:
+	:undoc-members:
+	:show-inheritance:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -9,6 +9,14 @@ Extract Links
 	:undoc-members:
 	:show-inheritance:
 
+GitHub Environment
+-------------------
+
+.. automodule:: markdown_checker.utils.github_env
+	:members:
+	:undoc-members:
+	:show-inheritance:
+
 List Files
 ----------
 
@@ -21,6 +29,14 @@ Spinner
 -------
 
 .. automodule:: markdown_checker.utils.spinner
+	:members:
+	:undoc-members:
+	:show-inheritance:
+
+URL Pipeline
+------------
+
+.. automodule:: markdown_checker.utils.url_pipeline
 	:members:
 	:undoc-members:
 	:show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
     "sphinxcontrib.log_cabinet",
     "sphinx_tabs.tabs",
     "sphinx_copybutton",
@@ -23,6 +24,9 @@ extensions = [
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 autodoc_preserve_defaults = True
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+napoleon_use_rtype = False
 extlinks = {
     "issue": ("https://github.com/john0isaac/markdown-checker/issues/%s", "#%s"),
     "pr": ("https://github.com/john0isaac/markdown-checker/pull/%s", "#%s"),

--- a/src/markdown_checker/__init__.py
+++ b/src/markdown_checker/__init__.py
@@ -1,5 +1,5 @@
 """
-markdown-checker — a markdown link validation reporting tool.
+markdown-checker - a markdown link validation reporting tool.
 """
 
 __version__ = "1.2.0"

--- a/src/markdown_checker/checker.py
+++ b/src/markdown_checker/checker.py
@@ -1,3 +1,4 @@
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import field
@@ -7,6 +8,16 @@ from markdown_checker.checks import REGISTRY
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownLinkBase
 from markdown_checker.utils import get_links_from_md_file
+from markdown_checker.utils.url_pipeline import URLCheckService
+
+# Bounds on how many files may have their check submitted (but not yet collected) at
+# once. The window drains early once enough links are in flight to keep every worker
+# fed (target ~2x max_workers), so link-dense files don't balloon memory; it never
+# drains before _MIN_FILE_WINDOW files, so link-sparse files (few links per file) still
+# get real cross-file overlap; _MAX_FILE_WINDOW is an absolute cap regardless of
+# link density.
+_MIN_FILE_WINDOW = 4
+_MAX_FILE_WINDOW = 64
 
 
 @dataclass
@@ -21,6 +32,7 @@ def detect_issues(
     func: str,
     file_path: Path,
     config: Config,
+    service: URLCheckService | None = None,
 ) -> tuple[list[MarkdownLinkBase], int]:
     """
     Detect issues in a single markdown file using the named check.
@@ -29,6 +41,8 @@ def detect_issues(
         func (str): Name of the check to run (must be a key in REGISTRY).
         file_path (Path): Path to the markdown file to check.
         config (Config): Runtime configuration for the check.
+        service: Optional shared URL-checking pipeline, reused across files
+            in a run so duplicate URLs are only checked once.
 
     Returns:
         A tuple of (detected_issues, links_checked_count).
@@ -44,7 +58,7 @@ def detect_issues(
     if not all_links.paths and not all_links.urls:
         return [], 0
 
-    detected_issues = check.run(links=all_links, config=config)
+    detected_issues = check.run(links=all_links, config=config, service=service)
 
     links_count = len(all_links.paths) if check.link_type == "paths" else len(all_links.urls)
     return detected_issues, links_count
@@ -59,11 +73,22 @@ def run_check_on_files(
     """
     Run a named check across multiple files.
 
+    Files are processed through an adaptive window: a file's check is submitted
+    (but not necessarily collected) as soon as it's reached, so link extraction
+    for upcoming files overlaps with the network wait of files already submitted.
+    The window drains early once roughly ``2 * config.max_workers`` links are in
+    flight - enough to keep every worker fed without link-dense files ballooning
+    memory - but never before ``_MIN_FILE_WINDOW`` files, so link-sparse files
+    still get real overlap; ``_MAX_FILE_WINDOW`` is an absolute cap either way.
+    ``progress_callback`` fires as each file is submitted rather than once its
+    results are collected, so the bar advances smoothly instead of lagging
+    behind in bursts.
+
     Args:
         func: Name of the check to run (must be a key in REGISTRY).
         files_paths: List of markdown file paths to check.
         config: Runtime configuration for the check.
-        progress_callback: Callback invoked after each file is checked.
+        progress_callback: Callback invoked once each file has been submitted.
 
     Returns:
         A CheckResult with per-file issues and total links checked.
@@ -73,12 +98,47 @@ def run_check_on_files(
         raise ValueError(f"Unknown check function: {func!r}. Available: {list(REGISTRY)}")
 
     result = CheckResult()
+    # Shared across all files so duplicate URLs are checked once, requests to the
+    # same host are paced, and a rate limit pauses that host instead of retrying
+    # it file-by-file.
+    service = URLCheckService(config) if check.link_type == "urls" else None
+    window: deque[tuple[Path, object, int]] = deque()
+    window_links = 0
+    target_links_in_flight = max(config.max_workers * 2, 1)
 
-    for file_path in files_paths:
-        detected_issues, links_count = detect_issues(func=func, file_path=file_path, config=config)
+    def drain_one() -> int:
+        """Collect the oldest submitted file and return its link count."""
+        file_path, pending, links_count = window.popleft()
+        detected_issues = check.collect(pending)
         result.links_checked += links_count
         if detected_issues:
             result.issues.append((file_path, detected_issues))
-        progress_callback()
+        return links_count
+
+    def window_full() -> bool:
+        if len(window) >= _MAX_FILE_WINDOW:
+            return True
+        return len(window) >= _MIN_FILE_WINDOW and window_links >= target_links_in_flight
+
+    try:
+        for file_path in files_paths:
+            all_links = get_links_from_md_file(file_path)
+            if not all_links.paths and not all_links.urls:
+                progress_callback()
+                continue
+
+            pending = check.submit(links=all_links, config=config, service=service)
+            links_count = len(all_links.paths) if check.link_type == "paths" else len(all_links.urls)
+            window.append((file_path, pending, links_count))
+            window_links += links_count
+            progress_callback()
+            if window_full():
+                window_links -= drain_one()
+
+        while window:
+            drain_one()
+    finally:
+        if service is not None:
+            service.close()
 
     return result

--- a/src/markdown_checker/checks/base.py
+++ b/src/markdown_checker/checks/base.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
+from typing import cast
 from typing import Generic
 from typing import Literal
 from typing import TypeVar
@@ -7,6 +8,7 @@ from typing import TypeVar
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownLinkBase
 from markdown_checker.utils.extract_links import MarkdownLinks
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 TLink = TypeVar("TLink", bound=MarkdownLinkBase, covariant=True)
 
@@ -22,6 +24,7 @@ class BaseCheck(Generic[TLink], ABC):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
+        service: URLCheckService | None = None,
     ) -> list[TLink]:
         """
         Run the check against the extracted links.
@@ -29,8 +32,51 @@ class BaseCheck(Generic[TLink], ABC):
         Args:
             links (MarkdownLinks): Extracted URLs and paths from a file.
             config: Runtime configuration for the check run.
+            service: Optional shared URL-checking pipeline (dedupe memo,
+                per-host pacing, circuit breaker). Only used by checks with
+                link_type "urls"; ignored otherwise. When None, URL checks
+                fall back to a private, run-scoped service instance.
 
         Returns:
             List of links that failed the check, each with an .issue set.
         """
         raise NotImplementedError
+
+    def submit(
+        self,
+        links: MarkdownLinks,
+        config: Config | None = None,
+        service: URLCheckService | None = None,
+    ) -> object:
+        """
+        Begin checking without blocking the caller, returning an opaque
+        "pending" token to be finished later via ``collect()``.
+
+        The default implementation simply runs the check synchronously and
+        hands the finished result to ``collect()`` unchanged - appropriate
+        for checks with no network I/O to overlap with other files. Checks
+        that can hand work off to a shared service (e.g. URL checks) should
+        override both ``submit()`` and ``collect()`` to split the non-blocking
+        submission from the blocking wait for results.
+
+        Args:
+            links (MarkdownLinks): Extracted URLs and paths from a file.
+            config: Runtime configuration for the check run.
+            service: Optional shared URL-checking pipeline.
+
+        Returns:
+            An opaque token to pass to ``collect()``.
+        """
+        return self.run(links=links, config=config, service=service)
+
+    def collect(self, pending: object) -> list[TLink]:
+        """
+        Resolve a pending token from ``submit()`` into final results.
+
+        Args:
+            pending: The token returned by a matching ``submit()`` call.
+
+        Returns:
+            List of links that failed the check, each with an .issue set.
+        """
+        return cast(list[TLink], pending)

--- a/src/markdown_checker/checks/broken_paths.py
+++ b/src/markdown_checker/checks/broken_paths.py
@@ -2,6 +2,7 @@ from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownPath
 from markdown_checker.utils.extract_links import MarkdownLinks
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 
 class BrokenPathsCheck(BaseCheck[MarkdownPath]):
@@ -14,6 +15,7 @@ class BrokenPathsCheck(BaseCheck[MarkdownPath]):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
+        service: URLCheckService | None = None,
     ) -> list[MarkdownPath]:
         detected_issues: list[MarkdownPath] = []
         for path in links.paths:

--- a/src/markdown_checker/checks/broken_urls.py
+++ b/src/markdown_checker/checks/broken_urls.py
@@ -1,38 +1,24 @@
-import concurrent.futures
-from functools import partial
+from concurrent.futures import Future
+from typing import cast
 
 from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
 from markdown_checker.utils.extract_links import MarkdownLinks
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 # Domains known to block automated requests (e.g. Cloudflare 403);
 # always skipped for URL checks.
 _BUILTIN_SKIP_DOMAINS: list[str] = []
 
+# Opaque token handed from submit() to collect(): the submitted jobs, plus the
+# service to close afterwards if this check created a private one for itself.
+_Pending = tuple[list[tuple[MarkdownURL, "Future[URLCheckResult]"]], URLCheckService | None]
 
-def _check_url(
-    url: MarkdownURL,
-    skip_domains: list[str],
-    skip_urls_containing: list[str],
-    timeout: int,
-    retries: int,
-    retry_on_429: bool,
-    fallback_retry_delay: int,
-) -> MarkdownURL | None:
-    """Thread worker: checks a single URL with its own httpx2 client."""
-    hostname = url.host_name().lower()
-    if any(domain in hostname for domain in skip_domains) or any(
-        substring in url.link for substring in skip_urls_containing
-    ):
-        return None
-    # Each worker creates its own client via check(client=None).
-    result = url.check(
-        timeout=timeout,
-        retries=retries,
-        retry_on_429=retry_on_429,
-        fallback_retry_delay=fallback_retry_delay,
-    )
+
+def _to_issue(url: MarkdownURL, result: URLCheckResult) -> MarkdownURL | None:
+    """Map a URLCheckResult onto a MarkdownURL's issue fields."""
     if result.status == "alive":
         return None
     if result.status == "broken":
@@ -56,29 +42,47 @@ class BrokenURLsCheck(BaseCheck[MarkdownURL]):
     name = "check_broken_urls"
     link_type = "urls"
 
-    def run(
+    def submit(
         self,
         links: MarkdownLinks,
         config: Config | None = None,
-    ) -> list[MarkdownURL]:
+        service: URLCheckService | None = None,
+    ) -> object:
         config = config or Config()
         effective_skip = [domain.lower() for domain in [*config.skip_domains, *_BUILTIN_SKIP_DOMAINS]]
         skip_urls_containing = config.skip_urls_containing
 
-        worker = partial(
-            _check_url,
-            skip_domains=effective_skip,
-            skip_urls_containing=skip_urls_containing,
-            timeout=config.timeout,
-            retries=config.retries,
-            retry_on_429=config.retry_on_429,
-            fallback_retry_delay=config.fallback_retry_delay,
-        )
-        # NOTE: httpx2.Client is NOT thread-safe. Do not share a single client
-        # across ThreadPoolExecutor workers. Each worker creates its own
-        # client via check(client=None) to avoid RuntimeError crashes.
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            results: list[MarkdownURL] = [
-                outcome for outcome in executor.map(worker, links.urls) if outcome is not None
-            ]
-        return results
+        # Standalone fallback (direct calls, tests): own a private service for this run only.
+        owns_service = service is None
+        _service = service or URLCheckService(config)
+
+        pending: list[tuple[MarkdownURL, Future[URLCheckResult]]] = []
+        for url in links.urls:
+            hostname = url.host_name().lower()
+            if any(domain in hostname for domain in effective_skip) or any(
+                substring in url.link for substring in skip_urls_containing
+            ):
+                continue
+            pending.append((url, _service.submit(url)))
+        return (pending, _service if owns_service else None)
+
+    def collect(self, pending: object) -> list[MarkdownURL]:
+        jobs, owned_service = cast(_Pending, pending)
+        try:
+            results: list[MarkdownURL] = []
+            for url, future in jobs:
+                issue = _to_issue(url, future.result())
+                if issue is not None:
+                    results.append(issue)
+            return results
+        finally:
+            if owned_service is not None:
+                owned_service.close()
+
+    def run(
+        self,
+        links: MarkdownLinks,
+        config: Config | None = None,
+        service: URLCheckService | None = None,
+    ) -> list[MarkdownURL]:
+        return self.collect(self.submit(links, config=config, service=service))

--- a/src/markdown_checker/checks/locale.py
+++ b/src/markdown_checker/checks/locale.py
@@ -2,6 +2,7 @@ from markdown_checker.checks.base import BaseCheck
 from markdown_checker.models import Config
 from markdown_checker.models import MarkdownURL
 from markdown_checker.utils.extract_links import MarkdownLinks
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 # Domains where locale is required in the URL path; always skipped for locale checks.
 _BUILTIN_SKIP_DOMAINS: list[str] = [
@@ -19,6 +20,7 @@ class URLsLocaleCheck(BaseCheck[MarkdownURL]):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
+        service: URLCheckService | None = None,
     ) -> list[MarkdownURL]:
         config = config or Config()
         effective_skip = [*config.skip_domains, *_BUILTIN_SKIP_DOMAINS]

--- a/src/markdown_checker/checks/tracking.py
+++ b/src/markdown_checker/checks/tracking.py
@@ -3,6 +3,7 @@ from markdown_checker.models import Config
 from markdown_checker.models import MarkdownPath
 from markdown_checker.models import MarkdownURL
 from markdown_checker.utils.extract_links import MarkdownLinks
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 
 class URLsTrackingCheck(BaseCheck[MarkdownURL]):
@@ -15,6 +16,7 @@ class URLsTrackingCheck(BaseCheck[MarkdownURL]):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
+        service: URLCheckService | None = None,
     ) -> list[MarkdownURL]:
         config = config or Config()
         skip_domains = config.skip_domains
@@ -44,6 +46,7 @@ class PathsTrackingCheck(BaseCheck[MarkdownPath]):
         self,
         links: MarkdownLinks,
         config: Config | None = None,
+        service: URLCheckService | None = None,
     ) -> list[MarkdownPath]:
         detected_issues: list[MarkdownPath] = []
         for path in links.paths:

--- a/src/markdown_checker/cli.py
+++ b/src/markdown_checker/cli.py
@@ -146,6 +146,23 @@ class ListOfStrings(click.Option):
     required=False,
 )
 @click.option(
+    "-mw",
+    "--max-workers",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Maximum number of concurrent URL-check workers. Defaults to 10, "
+    "or the number of available CPUs when running in GitHub Actions.",
+    required=False,
+)
+@click.option(
+    "-phd",
+    "--per-host-delay",
+    type=click.FloatRange(0.0, 10.0),
+    default=0.5,
+    help="Minimum delay in seconds between requests to the same host.",
+    required=False,
+)
+@click.option(
     "-o",
     "--output-file-name",
     type=str,
@@ -172,9 +189,17 @@ def main(
     retries: int,
     retry_on_429: bool,
     fallback_retry_delay: int,
+    max_workers: int | None,
+    per_host_delay: float,
     output_file_name: str,
 ) -> None:
     """A markdown link validation reporting tool."""
+    if max_workers is None:
+        if os.getenv("GITHUB_ACTIONS") == "true":
+            max_workers = max(1, os.cpu_count() or 10)
+        else:
+            max_workers = 10
+
     if src:
         files_paths = []
         for p in src:
@@ -199,6 +224,8 @@ def main(
         retries=retries,
         retry_on_429=retry_on_429,
         fallback_retry_delay=fallback_retry_delay,
+        max_workers=max_workers,
+        per_host_delay=per_host_delay,
         output_mode="ci" if os.getenv("CI", "false") == "true" else "local",
     )
     repo_url = get_github_repo_blob_url() if config.output_mode == "ci" else None

--- a/src/markdown_checker/models/config.py
+++ b/src/markdown_checker/models/config.py
@@ -30,4 +30,7 @@ class Config:
     retries: int = 3
     retry_on_429: bool = True
     fallback_retry_delay: int = 30
+    max_workers: int = 10
+    per_host_delay: float = 0.5
+    max_pending: int = 200
     output_mode: Literal["ci", "local"] = "local"

--- a/src/markdown_checker/models/url.py
+++ b/src/markdown_checker/models/url.py
@@ -83,6 +83,13 @@ class MarkdownURL(MarkdownLinkBase):
         """
         Check whether the URL is reachable and return a typed outcome.
 
+        Rate-limit signals (429, or any non-success response carrying a
+        Retry-After header) and auth errors (401/403) are returned
+        immediately without sleeping or retrying: retrying them wastes
+        traffic against hosts that are already blocking or throttling us.
+        Callers that want to wait out a rate limit (e.g. a host-level
+        circuit breaker) should do so themselves using ``retry_after``.
+
         Args:
             timeout (int): Timeout for the request in seconds.
             retries (int): Number of retries if the request fails.
@@ -92,44 +99,40 @@ class MarkdownURL(MarkdownLinkBase):
 
         Returns:
             URLCheckResult with status one of: ``alive``, ``broken``,
-            ``rate_limited``, or ``transient_error``.
+            ``rate_limited``, ``unverifiable``, or ``transient_error``.
         """
         _client = client or create_http_client()
         last_status_code: int | None = None
-        last_retry_after: int | None = None
         saw_hard_failure = False
-        saw_rate_limit = False
-        saw_auth_error = False
         try:
             for attempt in range(retries):
-                sleep_override: float | None = None
                 try:
                     response = _client.head(self.link, timeout=timeout)
                     last_status_code = response.status_code
                     if response.is_success:
                         return URLCheckResult(status="alive", http_status_code=response.status_code)
                     if retry_on_429:
-                        sleep_override = _retry_after_delay(response, fallback_retry_delay)
-                    if sleep_override is not None:
-                        saw_rate_limit = True
-                        last_retry_after = int(sleep_override)
-                    else:
-                        # Fall back to GET — some servers reject HEAD but allow GET.
-                        response = _client.get(self.link, timeout=timeout)
-                        last_status_code = response.status_code
-                        if response.is_success:
-                            return URLCheckResult(status="alive", http_status_code=response.status_code)
-                        if retry_on_429:
-                            sleep_override = _retry_after_delay(response, fallback_retry_delay)
-                        if sleep_override is not None:
-                            saw_rate_limit = True
-                            last_retry_after = int(sleep_override)
-                        elif response.status_code in (401, 403):
-                            # 401/403 means the server exists but is blocking automated access.
-                            # We cannot determine the real status of the resource.
-                            saw_auth_error = True
-                        else:
-                            saw_hard_failure = True
+                        delay = _retry_after_delay(response, fallback_retry_delay)
+                        if delay is not None:
+                            return URLCheckResult(
+                                status="rate_limited", http_status_code=response.status_code, retry_after=int(delay)
+                            )
+                    # Fall back to GET - some servers reject HEAD but allow GET.
+                    response = _client.get(self.link, timeout=timeout)
+                    last_status_code = response.status_code
+                    if response.is_success:
+                        return URLCheckResult(status="alive", http_status_code=response.status_code)
+                    if retry_on_429:
+                        delay = _retry_after_delay(response, fallback_retry_delay)
+                        if delay is not None:
+                            return URLCheckResult(
+                                status="rate_limited", http_status_code=response.status_code, retry_after=int(delay)
+                            )
+                    if response.status_code in (401, 403):
+                        # 401/403 means the server exists but is blocking automated access.
+                        # Retrying will not change the outcome, so return immediately.
+                        return URLCheckResult(status="unverifiable", http_status_code=response.status_code)
+                    saw_hard_failure = True
                 except httpx2.UnsupportedProtocol:
                     # Server redirected to a non-HTTP scheme (e.g. vscode://).
                     # The original URL is reachable; treat it as alive.
@@ -137,19 +140,10 @@ class MarkdownURL(MarkdownLinkBase):
                 except (httpx2.HTTPError, RuntimeError):
                     pass
                 if attempt < retries - 1:
-                    if sleep_override is not None:
-                        time.sleep(sleep_override)
-                    else:
-                        time.sleep(0.5 * 2**attempt)
+                    time.sleep(0.5 * 2**attempt)
         finally:
             if client is None:
                 _client.close()
         if saw_hard_failure:
             return URLCheckResult(status="broken", http_status_code=last_status_code)
-        if saw_rate_limit:
-            return URLCheckResult(
-                status="rate_limited", http_status_code=last_status_code, retry_after=last_retry_after
-            )
-        if saw_auth_error:
-            return URLCheckResult(status="unverifiable", http_status_code=last_status_code)
         return URLCheckResult(status="transient_error", http_status_code=None)

--- a/src/markdown_checker/patterns.py
+++ b/src/markdown_checker/patterns.py
@@ -1,15 +1,6 @@
-"""Central registry of all compiled regular expressions used across the package.
-
-This module lives at the top level (not inside `utils`) so it has no
-dependency on `markdown_checker.utils`, whose `__init__.py` eagerly imports
-`extract_links`. Importing this module from `models/base.py` (or anywhere
-else) must never re-enter that package's `__init__.py`, or it creates a
-circular import.
-"""
+"""Central registry of all compiled regular expressions used across the package."""
 
 import re
-
-# --- utils/extract_links.py -------------------------------------------------
 
 # Matches the (...) destination of an inline markdown link. Plain destinations
 # may contain one level of balanced parentheses (e.g. wikipedia URLs); <...>
@@ -27,12 +18,10 @@ SCHEME_PATTERN = re.compile(r"\A[A-Za-z][A-Za-z0-9+.-]*:")
 # Opening/closing code fence: at most 3 spaces of indentation per CommonMark.
 FENCE_OPEN_PATTERN = re.compile(r"^ {0,3}(`{3,}|~{3,})")
 
-# --- models/base.py ----------------------------------------------------------
 
 LOCALE_PATTERN = re.compile(r"/[a-z]{2}-[a-z]{2}/", re.IGNORECASE)
 TRACKING_PATTERN = re.compile(r"[?&]wt\.mc_id=", re.IGNORECASE)
 
-# --- models/path.py ------------------------------------------------------------
 
 # Same as TRACKING_PATTERN but also consumes the rest of the query string.
 TRACKING_QUERY_PATTERN = re.compile(TRACKING_PATTERN.pattern + ".*", TRACKING_PATTERN.flags)

--- a/src/markdown_checker/utils/url_pipeline.py
+++ b/src/markdown_checker/utils/url_pipeline.py
@@ -1,0 +1,254 @@
+"""Run-scoped URL checking pipeline.
+
+Provides a single ``URLCheckService`` shared across all files in a run that:
+
+- Checks each unique normalized URL exactly once (in-memory memo), and shares
+  the in-flight result with any duplicate occurrences submitted concurrently.
+- Serializes requests to the same host with a politeness delay between them.
+- Applies a host-level circuit breaker: a rate-limited response pauses the
+  whole host until its Retry-After window elapses, instead of every URL on
+  that host independently discovering and retrying the rate limit. A second
+  consecutive rate limit for the same host is treated as persistent
+  throttling: every other job already queued for that host is resolved as
+  rate_limited without spending a network request on each, and the host is
+  blocked from new dispatches until the cooldown elapses.
+- Bounds memory via backpressure: ``submit()`` blocks once ``max_pending``
+  jobs are in flight, so memory stays flat regardless of repo size.
+
+``submit()`` must only be called from a single producer thread for the
+lifetime of a service instance; a second calling thread raises RuntimeError.
+"""
+
+import heapq
+import threading
+import time
+from collections import deque
+from concurrent.futures import Future
+from dataclasses import dataclass
+from dataclasses import field
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+import httpx2
+
+from markdown_checker.models.config import Config
+from markdown_checker.models.config import create_http_client
+from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
+
+
+def normalize_url(link: str) -> str:
+    """
+    Normalize a URL into a dedupe key.
+
+    Lowercases the scheme and host, strips a trailing slash from the path,
+    and drops the fragment. Query strings are preserved as-is.
+
+    Args:
+        link (str): The raw URL to normalize.
+
+    Returns:
+        The normalized URL string used as the memo/dedupe key.
+    """
+    parts = urlparse(link)
+    return urlunparse(
+        (parts.scheme.lower(), parts.netloc.lower(), parts.path.rstrip("/"), parts.params, parts.query, "")
+    )
+
+
+@dataclass(slots=True)
+class _Job:
+    """A single unique-URL check pending in the pipeline."""
+
+    key: str
+    url: MarkdownURL
+    future: "Future[URLCheckResult]"
+    requeues: int = 0
+
+
+@dataclass(slots=True)
+class _HostState:
+    """Per-host queue and pacing state."""
+
+    jobs: "deque[_Job]" = field(default_factory=deque)
+    next_ready_at: float = 0.0
+    in_heap: bool = False
+    busy: bool = False
+    blocked_until: float = 0.0
+    """Set after two consecutive rate-limit signals for this host. Until this
+    time elapses, jobs for this host are resolved as rate_limited without
+    spending a network request on each - see _run_job / submit."""
+
+
+class URLCheckService:
+    """Run-scoped URL checking: dedupe memo, per-host pacing, host circuit breaker."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._cond = threading.Condition()
+        self._results: dict[str, Future[URLCheckResult]] = {}
+        self._pending: dict[str, _Job] = {}
+        self._hosts: dict[str, _HostState] = {}
+        self._heap: list[tuple[float, int, str]] = []
+        self._seq = 0
+        self._backpressure = threading.BoundedSemaphore(config.max_pending)
+        self._shutdown = False
+        self._producer_thread_id: int | None = None
+        self._workers = [
+            threading.Thread(target=self._worker, daemon=True, name=f"url-check-{i}") for i in range(config.max_workers)
+        ]
+        for worker in self._workers:
+            worker.start()
+
+    # -- producer side (must be called from a single thread) -------------
+
+    def submit(self, url: MarkdownURL) -> "Future[URLCheckResult]":
+        """
+        Submit a URL for checking, deduped against the run-wide memo.
+
+        Returns a Future that resolves once the underlying unique URL has
+        been checked. Duplicate submissions of the same normalized URL,
+        whether already resolved or still in flight, share the same result
+        without triggering additional network activity.
+
+        Must only ever be called from a single thread for the lifetime of a
+        service instance; calling it from more than one thread raises
+        RuntimeError, since the memo/backpressure handshake below is not safe
+        under concurrent producers.
+        """
+        key = normalize_url(url.link)
+        with self._cond:
+            self._check_single_producer_locked()
+            if key in self._results:
+                return self._results[key]
+            if key in self._pending:
+                return self._pending[key].future
+
+        # Blocks when max_pending jobs are in flight (backpressure keeps memory bounded).
+        self._backpressure.acquire()
+        job = _Job(key=key, url=url, future=Future())
+        hostname = url.host_name().lower()
+        with self._cond:
+            self._pending[key] = job
+            host = self._hosts.setdefault(hostname, _HostState())
+            now = time.monotonic()
+            if now < host.blocked_until:
+                # Host is cooling down after repeated rate limiting; resolve immediately
+                # instead of queueing behind an already-blocked host.
+                self._finalize_locked(
+                    job,
+                    URLCheckResult(
+                        status="rate_limited", http_status_code=None, retry_after=int(host.blocked_until - now)
+                    ),
+                )
+            else:
+                host.jobs.append(job)
+                self._schedule_host_locked(hostname, host)
+                self._cond.notify()
+        return job.future
+
+    def close(self) -> None:
+        """Shut down worker threads. Call only after all submitted Futures have resolved."""
+        with self._cond:
+            self._shutdown = True
+            self._cond.notify_all()
+        for worker in self._workers:
+            worker.join()
+
+    # -- scheduling / bookkeeping (all called with self._cond held) -------
+
+    def _check_single_producer_locked(self) -> None:
+        current = threading.get_ident()
+        if self._producer_thread_id is None:
+            self._producer_thread_id = current
+        elif current != self._producer_thread_id:
+            raise RuntimeError(
+                "URLCheckService.submit() must only be called from a single producer thread "
+                f"(first called from thread {self._producer_thread_id}, now called from thread {current})."
+            )
+
+    def _finalize_locked(self, job: _Job, result: URLCheckResult) -> None:
+        """Resolve a job with its final result: cache the completed future, free its permit."""
+        job.future.set_result(result)
+        self._results[job.key] = job.future
+        del self._pending[job.key]
+        self._backpressure.release()
+
+    def _schedule_host_locked(self, hostname: str, host: _HostState) -> None:
+        if host.jobs and not host.in_heap and not host.busy:
+            self._seq += 1
+            heapq.heappush(self._heap, (host.next_ready_at, self._seq, hostname))
+            host.in_heap = True
+
+    def _next_ready_host_locked(self) -> str | None:
+        now = time.monotonic()
+        while self._heap and self._heap[0][0] <= now:
+            _, _, hostname = heapq.heappop(self._heap)
+            host = self._hosts[hostname]
+            host.in_heap = False
+            if host.jobs and not host.busy:
+                return hostname
+        return None
+
+    def _wait_timeout_locked(self) -> float | None:
+        if not self._heap:
+            return None
+        return max(0.0, self._heap[0][0] - time.monotonic())
+
+    def _worker(self) -> None:
+        client = create_http_client()
+        try:
+            while True:
+                with self._cond:
+                    hostname = self._next_ready_host_locked()
+                    while hostname is None:
+                        if self._shutdown:
+                            return
+                        self._cond.wait(timeout=self._wait_timeout_locked())
+                        hostname = self._next_ready_host_locked()
+                    host = self._hosts[hostname]
+                    host.busy = True
+                    job = host.jobs.popleft()
+                self._run_job(client, hostname, host, job)
+        finally:
+            client.close()
+
+    def _run_job(self, client: httpx2.Client, hostname: str, host: _HostState, job: _Job) -> None:
+        try:
+            result = job.url.check(
+                timeout=self._config.timeout,
+                retries=self._config.retries,
+                client=client,
+                retry_on_429=self._config.retry_on_429,
+                fallback_retry_delay=self._config.fallback_retry_delay,
+            )
+        except Exception:  # noqa: BLE001 - a worker crashing must not hang collect() forever
+            # Treat it like any other unreachable-URL outcome instead of propagating: one
+            # unexpected exception shouldn't abort collection of every other file's results.
+            result = URLCheckResult(status="transient_error", http_status_code=None)
+
+        now = time.monotonic()
+        with self._cond:
+            host.busy = False
+            if result.status == "rate_limited":
+                if job.requeues < 1:
+                    # First rate-limit signal for this job: wait out the window, then retry once.
+                    job.requeues += 1
+                    host.jobs.appendleft(job)
+                    host.next_ready_at = now + (result.retry_after or self._config.fallback_retry_delay)
+                else:
+                    # Persistent throttling: two rate-limit signals in a row for this host.
+                    # Stop probing it job-by-job - drain every other job currently queued
+                    # for this host as rate_limited without spending a network request on
+                    # each, and block new submissions to this host until the cooldown ends.
+                    cooldown_until = now + (result.retry_after or self._config.fallback_retry_delay)
+                    host.blocked_until = cooldown_until
+                    host.next_ready_at = cooldown_until
+                    self._finalize_locked(job, result)
+                    while host.jobs:
+                        self._finalize_locked(host.jobs.popleft(), result)
+            else:
+                self._finalize_locked(job, result)
+                host.next_ready_at = now + self._config.per_host_delay
+            self._schedule_host_locked(hostname, host)
+            self._cond.notify_all()

--- a/tests/smoke/test_cli_smoke.py
+++ b/tests/smoke/test_cli_smoke.py
@@ -1,4 +1,4 @@
-"""Smoke tests — run the CLI end-to-end against sample markdown files."""
+"""Smoke tests - run the CLI end-to-end against sample markdown files."""
 
 from pathlib import Path
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,10 +1,15 @@
+import threading
+import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from markdown_checker.checker import detect_issues
 from markdown_checker.checker import run_check_on_files
 from markdown_checker.models.config import Config
+from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
 
 
 def test_detect_issues_unknown_func_raises():
@@ -150,3 +155,113 @@ def test_run_check_on_files(tmp_path):
     assert len(result.issues) == 1
     assert result.issues[0][0] == md1
     assert result.links_checked == 1
+
+
+# --- Stage 2: bounded file-window pipelining ---
+
+
+def test_run_check_on_files_overlaps_url_checks_across_files(tmp_path):
+    """URL checks for multiple files are submitted concurrently instead of one file at a time."""
+    files = []
+    for i in range(3):
+        md = tmp_path / f"file{i}.md"
+        md.write_text(f"[link](https://host{i}.example.com/page)\n")
+        files.append(md)
+
+    def slow_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        time.sleep(0.2)
+        return URLCheckResult(status="alive", http_status_code=200)
+
+    config = Config(max_workers=3, per_host_delay=0.0)
+    start = time.monotonic()
+    with patch.object(MarkdownURL, "check", slow_check):
+        result = run_check_on_files(
+            func="check_broken_urls",
+            files_paths=files,
+            config=config,
+            progress_callback=lambda: None,
+        )
+    elapsed = time.monotonic() - start
+
+    assert result.links_checked == 3
+    assert result.issues == []
+    # Sequential (Stage 1) would take ~3 * 0.2s = 0.6s; overlapping submission keeps it near 0.2s.
+    assert elapsed < 0.4, f"expected overlapping checks (~0.2s), took {elapsed:.2f}s"
+
+
+def test_run_check_on_files_smaller_than_window_size_still_correct(tmp_path, monkeypatch):
+    """More files than the window still produce complete, correctly ordered results."""
+    monkeypatch.setattr("markdown_checker.checker._MIN_FILE_WINDOW", 1)
+    monkeypatch.setattr("markdown_checker.checker._MAX_FILE_WINDOW", 2)
+    files = []
+    for i in range(5):
+        md = tmp_path / f"f{i}.md"
+        md.write_text(f"[link](https://broken{i}.example.com/page)\n")
+        files.append(md)
+
+    broken_result = URLCheckResult(status="broken", http_status_code=404)
+    with patch.object(MarkdownURL, "check", return_value=broken_result):
+        result = run_check_on_files(
+            func="check_broken_urls",
+            files_paths=files,
+            config=Config(),
+            progress_callback=lambda: None,
+        )
+
+    assert result.links_checked == 5
+    assert len(result.issues) == 5
+    assert [path for path, _ in result.issues] == files
+
+
+def test_window_admits_more_files_when_max_workers_is_larger(tmp_path, monkeypatch):
+    """The adaptive window scales with max_workers: more files get submitted (and their
+    checks dispatched) before the producer blocks collecting the oldest one."""
+    monkeypatch.setattr("markdown_checker.checker._MIN_FILE_WINDOW", 1)
+    monkeypatch.setattr("markdown_checker.checker._MAX_FILE_WINDOW", 100)
+
+    def make_files(prefix: str, n: int) -> list[Path]:
+        paths = []
+        for i in range(n):
+            md = tmp_path / f"{prefix}{i}.md"
+            md.write_text(f"[link](https://{prefix}-host{i}.example.com/page)\n")
+            paths.append(md)
+        return paths
+
+    def dispatched_before_block(max_workers: int, prefix: str) -> int:
+        files = make_files(prefix, 6)
+        release = threading.Event()
+        lock = threading.Lock()
+        calls: list[float] = []
+
+        def blocking_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+            with lock:
+                calls.append(time.monotonic())
+            release.wait(timeout=5)
+            return URLCheckResult(status="alive", http_status_code=200)
+
+        done = threading.Event()
+
+        def run() -> None:
+            with patch.object(MarkdownURL, "check", blocking_check):
+                run_check_on_files(
+                    func="check_broken_urls",
+                    files_paths=files,
+                    config=Config(max_workers=max_workers, per_host_delay=0.0),
+                    progress_callback=lambda: None,
+                )
+            done.set()
+
+        thread = threading.Thread(target=run)
+        thread.start()
+        time.sleep(0.3)  # let dispatch race ahead while every check() call is blocked
+        with lock:
+            observed = len(calls)
+        release.set()
+        thread.join(timeout=5)
+        assert done.is_set()
+        return observed
+
+    low = dispatched_before_block(max_workers=1, prefix="low")
+    high = dispatched_before_block(max_workers=6, prefix="high")
+
+    assert high > low

--- a/tests/test_checks_broken_urls.py
+++ b/tests/test_checks_broken_urls.py
@@ -4,11 +4,12 @@ from unittest.mock import patch
 import pytest
 
 from markdown_checker.checks.broken_urls import _BUILTIN_SKIP_DOMAINS
-from markdown_checker.checks.broken_urls import _check_url
+from markdown_checker.checks.broken_urls import _to_issue
 from markdown_checker.checks.broken_urls import BrokenURLsCheck
 from markdown_checker.models.config import Config
 from markdown_checker.models.url import MarkdownURL
 from markdown_checker.models.url import URLCheckResult
+from markdown_checker.utils.url_pipeline import URLCheckService
 
 
 @pytest.fixture
@@ -70,96 +71,54 @@ def test_skip_urls_containing(check, make_markdown_url, make_markdown_links):
     mock_check.assert_not_called()
 
 
-# --- Tests for _check_url helper ---
+# --- Tests for _to_issue helper ---
 
 
-def test_check_url_returns_none_for_skipped_domain():
-    """Returns None for URLs on skipped domains."""
-    url = MarkdownURL(link="https://github.com/page", line_number=1, file_path=Path("test.md"))
-    result = _check_url(
-        url,
-        skip_domains=["github.com"],
-        skip_urls_containing=[],
-        timeout=5,
-        retries=1,
-        retry_on_429=True,
-        fallback_retry_delay=60,
-    )
-    assert result is None
+def test_to_issue_skipped_domain_not_checked(check, make_markdown_url, make_markdown_links):
+    """URLs on skipped domains are never submitted for a network check."""
+    url = make_markdown_url("https://github.com/page")
+    links = make_markdown_links(urls=[url])
+    with patch.object(MarkdownURL, "check") as mock_check:
+        result = check.run(links, config=Config(skip_domains=["github.com"]))
+    mock_check.assert_not_called()
+    assert result == []
 
 
-def test_check_url_returns_url_for_broken():
-    """Returns the URL with issue set when it is not alive."""
+def test_to_issue_returns_url_for_broken():
+    """Returns the URL with issue set when the result is broken."""
     url = MarkdownURL(link="https://broken.example.com", line_number=1, file_path=Path("test.md"))
     broken_result = URLCheckResult(status="broken", http_status_code=404)
-    with patch.object(MarkdownURL, "check", return_value=broken_result):
-        result = _check_url(
-            url,
-            skip_domains=[],
-            skip_urls_containing=[],
-            timeout=5,
-            retries=1,
-            retry_on_429=True,
-            fallback_retry_delay=60,
-        )
+    result = _to_issue(url, broken_result)
     assert result is not None
     assert result.issue == "is broken"
     assert result.issue_level == "error"
 
 
-def test_check_url_returns_none_for_alive():
-    """Returns None for alive URLs."""
+def test_to_issue_returns_none_for_alive():
+    """Returns None for alive results."""
     url = MarkdownURL(link="https://alive.example.com", line_number=1, file_path=Path("test.md"))
     alive_result = URLCheckResult(status="alive", http_status_code=200)
-    with patch.object(MarkdownURL, "check", return_value=alive_result):
-        result = _check_url(
-            url,
-            skip_domains=[],
-            skip_urls_containing=[],
-            timeout=5,
-            retries=1,
-            retry_on_429=True,
-            fallback_retry_delay=60,
-        )
-    assert result is None
+    assert _to_issue(url, alive_result) is None
 
 
 # --- Rate-limiting tests ---
 
 
-def test_check_url_rate_limited_returns_warning_issue():
+def test_to_issue_rate_limited_returns_warning_issue():
     """rate_limited status: URL is returned with issue_level='warning' and issue set."""
     url = MarkdownURL(link="https://rate-limited.example.com", line_number=1, file_path=Path("test.md"))
     rate_limited_result = URLCheckResult(status="rate_limited", http_status_code=429, retry_after=30)
-    with patch.object(MarkdownURL, "check", return_value=rate_limited_result):
-        result = _check_url(
-            url,
-            skip_domains=[],
-            skip_urls_containing=[],
-            timeout=5,
-            retries=1,
-            retry_on_429=True,
-            fallback_retry_delay=30,
-        )
+    result = _to_issue(url, rate_limited_result)
     assert result is not None
     assert result.issue == "was skipped due to rate limiting"
     assert result.issue_level == "warning"
 
 
-def test_check_url_transient_error_returns_warning_issue():
+def test_to_issue_transient_error_returns_warning_issue():
     """transient_error status: URL is returned with issue_level='warning' and issue set."""
     url = MarkdownURL(link="https://flaky.example.com", line_number=1, file_path=Path("test.md"))
     transient_result = URLCheckResult(status="transient_error", http_status_code=None)
-    with patch.object(MarkdownURL, "check", return_value=transient_result):
-        result = _check_url(
-            url,
-            skip_domains=[],
-            skip_urls_containing=[],
-            timeout=5,
-            retries=1,
-            retry_on_429=True,
-            fallback_retry_delay=30,
-        )
+    result = _to_issue(url, transient_result)
     assert result is not None
     assert result.issue == "could not be reached due to a network error"
     assert result.issue_level == "warning"
@@ -210,3 +169,28 @@ def test_mixed_outcomes_broken_error_rate_limited_warning(check, make_markdown_u
     rate_limited = next(r for r in result if "rate-limited" in r.link)
     assert broken.issue_level == "error"
     assert rate_limited.issue_level == "warning"
+
+
+# --- Shared-service dedupe tests ---
+
+
+def test_shared_service_dedupes_duplicate_url_across_files(check, make_markdown_url, make_markdown_links):
+    """The same URL passed via a shared service is only checked once across two 'files'."""
+    config = Config()
+    service = URLCheckService(config)
+    try:
+        broken_result = URLCheckResult(status="broken", http_status_code=404)
+        with patch.object(MarkdownURL, "check", return_value=broken_result) as mock_check:
+            url_file1 = make_markdown_url("https://dup.example.com/page", file_path=Path("file1.md"))
+            url_file2 = make_markdown_url("https://dup.example.com/page", file_path=Path("file2.md"))
+
+            result1 = check.run(make_markdown_links(urls=[url_file1]), config=config, service=service)
+            result2 = check.run(make_markdown_links(urls=[url_file2]), config=config, service=service)
+
+        mock_check.assert_called_once()
+        assert len(result1) == 1
+        assert len(result2) == 1
+        assert result1[0].file_path == Path("file1.md")
+        assert result2[0].file_path == Path("file2.md")
+    finally:
+        service.close()

--- a/tests/test_models_url.py
+++ b/tests/test_models_url.py
@@ -107,49 +107,34 @@ def _make_response(status_code: int, headers: dict | None = None) -> MagicMock:
     return resp
 
 
-def test_check_429_with_retry_after_integer_sleeps_and_retries():
-    """429 + Retry-After: 2 → sleep(2) called, request retried, returns alive on success."""
+def test_check_429_with_retry_after_returns_immediately():
+    """429 + Retry-After: 2 → returns rate_limited immediately, no sleep or retry."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
-    rate_limited = _make_response(429, {"retry-after": "2"})
-    success = _make_response(200)
-    mock_client.head.side_effect = [rate_limited, success]
+    mock_client.head.return_value = _make_response(429, {"retry-after": "2"})
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+        result = url.check(timeout=5, retries=3, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
 
-    assert result.status == "alive"
-    mock_sleep.assert_called_once_with(2.0)
-    assert mock_client.head.call_count == 2
+    assert result.status == "rate_limited"
+    assert result.retry_after == 2
+    mock_sleep.assert_not_called()
+    mock_client.head.assert_called_once()
+    mock_client.get.assert_not_called()
 
 
-def test_check_429_without_retry_after_uses_fallback():
-    """429 with no Retry-After header → sleep(fallback_retry_delay) called."""
+def test_check_429_without_retry_after_uses_fallback_as_retry_after():
+    """429 with no Retry-After header → rate_limited returned with fallback_retry_delay as retry_after."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
-    rate_limited = _make_response(429, {})
-    success = _make_response(200)
-    mock_client.head.side_effect = [rate_limited, success]
+    mock_client.head.return_value = _make_response(429, {})
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
+        result = url.check(timeout=5, retries=3, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
 
-    assert result.status == "alive"
-    mock_sleep.assert_called_once_with(30.0)
-
-
-def test_check_429_retry_succeeds():
-    """After a 429, a successful retry means check returns alive."""
-    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    mock_client = MagicMock(spec=httpx2.Client)
-    rate_limited = _make_response(429, {"retry-after": "1"})
-    success = _make_response(200)
-    mock_client.head.side_effect = [rate_limited, success]
-
-    with patch("markdown_checker.models.url.time.sleep"):
-        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
-
-    assert result.status == "alive"
+    assert result.status == "rate_limited"
+    assert result.retry_after == 30
+    mock_sleep.assert_not_called()
 
 
 def test_is_alive_retry_on_429_disabled_uses_exponential_backoff():
@@ -169,20 +154,36 @@ def test_is_alive_retry_on_429_disabled_uses_exponential_backoff():
     mock_sleep.assert_called_once_with(0.5)
 
 
-def test_check_non_success_with_retry_after_header_uses_delay():
-    """Any non-success, non-redirect response with Retry-After is respected."""
+def test_check_non_success_with_retry_after_header_returns_rate_limited():
+    """Any non-success, non-redirect response with Retry-After returns rate_limited immediately."""
     url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
     mock_client = MagicMock(spec=httpx2.Client)
-    # 503 with Retry-After: 5 should also trigger the delay.
-    throttled = _make_response(503, {"retry-after": "5"})
-    success = _make_response(200)
-    mock_client.head.side_effect = [throttled, success]
+    # 503 with Retry-After: 5 should also trigger the immediate rate_limited return.
+    mock_client.head.return_value = _make_response(503, {"retry-after": "5"})
 
     with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
-        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
+        result = url.check(timeout=5, retries=3, client=mock_client, retry_on_429=True, fallback_retry_delay=60)
 
-    assert result.status == "alive"
-    mock_sleep.assert_called_once_with(5.0)
+    assert result.status == "rate_limited"
+    assert result.http_status_code == 503
+    assert result.retry_after == 5
+    mock_sleep.assert_not_called()
+
+
+def test_check_401_403_does_not_retry():
+    """401/403 responses return immediately without retrying - they will not change."""
+    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
+    mock_client = MagicMock(spec=httpx2.Client)
+    mock_client.head.return_value = _make_response(403)
+    mock_client.get.return_value = _make_response(403)
+
+    with patch("markdown_checker.models.url.time.sleep") as mock_sleep:
+        result = url.check(timeout=5, retries=5, client=mock_client)
+
+    assert result.status == "unverifiable"
+    mock_client.head.assert_called_once()
+    mock_client.get.assert_called_once()
+    mock_sleep.assert_not_called()
 
 
 def test_check_creates_client_when_none():
@@ -206,11 +207,6 @@ def test_check_does_not_close_provided_client():
     mock_client.close.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# URLCheckResult dataclass
-# ---------------------------------------------------------------------------
-
-
 def test_url_check_result_fields():
     """URLCheckResult stores all three fields."""
     r = URLCheckResult(status="alive", http_status_code=200, retry_after=None)
@@ -224,11 +220,6 @@ def test_url_check_result_defaults():
     r = URLCheckResult(status="broken")
     assert r.http_status_code is None
     assert r.retry_after is None
-
-
-# ---------------------------------------------------------------------------
-# check() method — four outcome values
-# ---------------------------------------------------------------------------
 
 
 def test_check_returns_alive_on_2xx():
@@ -265,20 +256,6 @@ def test_check_returns_rate_limited_when_429_exhausts_retries():
     assert result.status == "rate_limited"
     assert result.http_status_code == 429
     assert result.retry_after == 5
-
-
-def test_check_returns_broken_when_429_is_followed_by_404():
-    """A later hard HTTP failure should classify the URL as broken, not rate-limited."""
-    url = MarkdownURL(link="https://example.com", line_number=1, file_path=Path("test.md"))
-    mock_client = MagicMock(spec=httpx2.Client)
-    rate_limited = _make_response(429, {"retry-after": "5"})
-    not_found = _make_response(404)
-    mock_client.head.side_effect = [rate_limited, not_found]
-    mock_client.get.return_value = not_found
-    with patch("markdown_checker.models.url.time.sleep"):
-        result = url.check(timeout=5, retries=2, client=mock_client, retry_on_429=True, fallback_retry_delay=30)
-    assert result.status == "broken"
-    assert result.http_status_code == 404
 
 
 def test_check_returns_broken_when_network_error_is_followed_by_404():

--- a/tests/test_utils_url_pipeline.py
+++ b/tests/test_utils_url_pipeline.py
@@ -1,0 +1,347 @@
+import threading
+import time
+from concurrent.futures import Future
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from markdown_checker.models.config import Config
+from markdown_checker.models.url import MarkdownURL
+from markdown_checker.models.url import URLCheckResult
+from markdown_checker.utils.url_pipeline import normalize_url
+from markdown_checker.utils.url_pipeline import URLCheckService
+
+
+def _url(link: str, file_path: Path = Path("test.md")) -> MarkdownURL:
+    return MarkdownURL(link=link, line_number=1, file_path=file_path)
+
+
+# --- normalize_url ---
+
+
+@pytest.mark.parametrize(
+    "link, expected",
+    [
+        ("HTTPS://Example.COM/Path", "https://example.com/Path"),
+        ("https://example.com/path/", "https://example.com/path"),
+        ("https://example.com/path#fragment", "https://example.com/path"),
+        ("https://example.com/path?q=1", "https://example.com/path?q=1"),
+        ("https://example.com/", "https://example.com"),
+    ],
+)
+def test_normalize_url(link: str, expected: str):
+    """Lowercases scheme/host, strips trailing slash and fragment, keeps query."""
+    assert normalize_url(link) == expected
+
+
+# --- memo / dedupe ---
+
+
+def test_submit_memo_hit_avoids_second_check():
+    """A second submit() of an already-resolved URL does not trigger another check()."""
+    config = Config(max_workers=2)
+    service = URLCheckService(config)
+    try:
+        alive = URLCheckResult(status="alive", http_status_code=200)
+        with patch.object(MarkdownURL, "check", return_value=alive) as mock_check:
+            future1 = service.submit(_url("https://example.com/a"))
+            result1 = future1.result(timeout=5)
+            future2 = service.submit(_url("https://example.com/a"))
+            result2 = future2.result(timeout=5)
+        assert mock_check.call_count == 1
+        assert result1 is result2 is alive
+    finally:
+        service.close()
+
+
+def test_submit_in_flight_dedupe_shares_future():
+    """Two submits of the same URL while the first is still in flight share one Future."""
+    config = Config(max_workers=2)
+    service = URLCheckService(config)
+    release = threading.Event()
+    alive = URLCheckResult(status="alive", http_status_code=200)
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        release.wait(timeout=5)
+        return alive
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://example.com/b"))
+            # Give the worker a moment to pick up the job before submitting the duplicate.
+            time.sleep(0.05)
+            future2 = service.submit(_url("https://example.com/b"))
+            assert future1 is future2
+            release.set()
+            assert future1.result(timeout=5) is alive
+    finally:
+        release.set()
+        service.close()
+
+
+# --- per-host serialization ---
+
+
+def test_per_host_requests_never_overlap():
+    """Two URLs on the same host are never checked concurrently."""
+    config = Config(max_workers=4, per_host_delay=0.0)
+    service = URLCheckService(config)
+    lock = threading.Lock()
+    intervals: list[tuple[float, float]] = []
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        start = time.monotonic()
+        time.sleep(0.05)
+        end = time.monotonic()
+        with lock:
+            intervals.append((start, end))
+        return URLCheckResult(status="alive", http_status_code=200)
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://same-host.example.com/1"))
+            future2 = service.submit(_url("https://same-host.example.com/2"))
+            future1.result(timeout=5)
+            future2.result(timeout=5)
+    finally:
+        service.close()
+
+    assert len(intervals) == 2
+    (start_a, end_a), (start_b, end_b) = sorted(intervals)
+    assert end_a <= start_b, "requests to the same host overlapped"
+
+
+def test_different_hosts_are_not_serialized():
+    """URLs on different hosts are not blocked by each other's pacing."""
+    config = Config(max_workers=4, per_host_delay=0.0)
+    service = URLCheckService(config)
+    barrier = threading.Barrier(2, timeout=5)
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        barrier.wait()  # only succeeds if both hosts are being checked concurrently
+        return URLCheckResult(status="alive", http_status_code=200)
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://host-a.example.com/1"))
+            future2 = service.submit(_url("https://host-b.example.com/1"))
+            assert future1.result(timeout=5).status == "alive"
+            assert future2.result(timeout=5).status == "alive"
+    finally:
+        service.close()
+
+
+def test_per_host_delay_paces_consecutive_requests():
+    """Consecutive requests to the same host are spaced by at least per_host_delay."""
+    config = Config(max_workers=1, per_host_delay=0.2)
+    service = URLCheckService(config)
+    timestamps: list[float] = []
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        timestamps.append(time.monotonic())
+        return URLCheckResult(status="alive", http_status_code=200)
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://paced.example.com/1"))
+            future2 = service.submit(_url("https://paced.example.com/2"))
+            future1.result(timeout=5)
+            future2.result(timeout=5)
+    finally:
+        service.close()
+
+    assert len(timestamps) == 2
+    assert timestamps[1] - timestamps[0] >= 0.2 - 0.01
+
+
+# --- host-level circuit breaker ---
+
+
+def test_rate_limit_pauses_host_and_requeues_once():
+    """A rate_limited result pauses the host until retry_after elapses, then retries once."""
+    config = Config(max_workers=1, per_host_delay=0.0)
+    service = URLCheckService(config)
+    call_times: list[float] = []
+    rate_limited = URLCheckResult(status="rate_limited", http_status_code=429, retry_after=1)
+    alive = URLCheckResult(status="alive", http_status_code=200)
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        call_times.append(time.monotonic())
+        return rate_limited if len(call_times) == 1 else alive
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            start = time.monotonic()
+            future = service.submit(_url("https://throttled.example.com/1"))
+            result = future.result(timeout=5)
+    finally:
+        service.close()
+
+    assert result.status == "alive"
+    assert len(call_times) == 2
+    assert call_times[1] - start >= 1 - 0.05, "retry happened before the retry_after window elapsed"
+
+
+def test_persistent_rate_limit_drains_queued_jobs_without_network():
+    """Two consecutive rate-limited results for a host drain every other queued job for
+    that host as rate_limited too, without spending a network request on each."""
+    config = Config(max_workers=1, per_host_delay=0.0)
+    service = URLCheckService(config)
+    calls: list[float] = []
+    rate_limited = URLCheckResult(status="rate_limited", http_status_code=429, retry_after=0.3)
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        calls.append(time.monotonic())
+        return rate_limited
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://persistent.example.com/1"))
+            future2 = service.submit(_url("https://persistent.example.com/2"))
+            result1 = future1.result(timeout=5)
+            result2 = future2.result(timeout=5)
+    finally:
+        service.close()
+
+    assert result1.status == "rate_limited"
+    assert result2.status == "rate_limited"
+    # job1 is checked twice (initial + one requeue) before the host is marked persistent;
+    # job2 is drained directly from the queue and never reaches the network.
+    assert len(calls) == 2
+
+
+def test_persistent_rate_limit_blocks_new_submissions_during_cooldown():
+    """A new submission for a host that is mid-cooldown is resolved immediately."""
+    config = Config(max_workers=1, per_host_delay=0.0)
+    service = URLCheckService(config)
+    calls: list[float] = []
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        calls.append(time.monotonic())
+        # Short wait before the requeued attempt, then a long cooldown once persistent
+        # throttling is detected, so the test stays fast but still exercises the window.
+        retry_after = 0.2 if len(calls) == 1 else 5
+        return URLCheckResult(status="rate_limited", http_status_code=429, retry_after=retry_after)
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            future1 = service.submit(_url("https://cooldown.example.com/1"))
+            result1 = future1.result(timeout=5)
+            # By now the host has requeued once and hit persistent throttling (2 calls) and
+            # is blocked for ~5s. A submission arriving during that window must not queue.
+            future2 = service.submit(_url("https://cooldown.example.com/2"))
+            result2 = future2.result(timeout=5)
+    finally:
+        service.close()
+
+    assert result1.status == "rate_limited"
+    assert result2.status == "rate_limited"
+    assert len(calls) == 2, "the second URL should have been drained, not sent over the network"
+
+
+# --- backpressure ---
+
+
+def test_backpressure_blocks_submit_until_slot_frees():
+    """submit() blocks the single producer thread once max_pending jobs are outstanding."""
+    config = Config(max_workers=2, max_pending=2, per_host_delay=0.0)
+    service = URLCheckService(config)
+    release = threading.Event()
+    alive = URLCheckResult(status="alive", http_status_code=200)
+
+    def fake_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        if "host-c" not in self.link:
+            release.wait(timeout=5)
+        return alive
+
+    third_submitted = threading.Event()
+    futures: list[Future[URLCheckResult]] = []
+
+    def producer() -> None:
+        # All submissions come from this single producer thread, per the single-producer contract.
+        futures.append(service.submit(_url("https://host-a.example.com/1")))
+        futures.append(service.submit(_url("https://host-b.example.com/1")))
+        # Both permits are now held by the blocking jobs above; this call must block until
+        # one of them completes and releases a permit.
+        futures.append(service.submit(_url("https://host-c.example.com/1")))
+        third_submitted.set()
+
+    try:
+        with patch.object(MarkdownURL, "check", fake_check):
+            thread = threading.Thread(target=producer)
+            thread.start()
+            time.sleep(0.2)
+            assert not third_submitted.is_set(), "submit() did not apply backpressure"
+
+            release.set()
+            thread.join(timeout=5)
+            assert third_submitted.is_set()
+            assert futures[2].result(timeout=5).status == "alive"
+    finally:
+        release.set()
+        service.close()
+
+
+# --- single-producer contract ---
+
+
+def test_submit_from_second_thread_raises():
+    """submit() from a second thread after the first raises RuntimeError."""
+    config = Config(max_workers=1)
+    service = URLCheckService(config)
+    alive = URLCheckResult(status="alive", http_status_code=200)
+    errors: list[BaseException] = []
+
+    def other_thread_submit() -> None:
+        try:
+            service.submit(_url("https://second-thread.example.com/1"))
+        except BaseException as exc:  # noqa: BLE001 - captured to assert on in the test thread
+            errors.append(exc)
+
+    try:
+        with patch.object(MarkdownURL, "check", return_value=alive):
+            service.submit(_url("https://first-thread.example.com/1")).result(timeout=5)
+            thread = threading.Thread(target=other_thread_submit)
+            thread.start()
+            thread.join(timeout=5)
+    finally:
+        service.close()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+    assert "single producer thread" in str(errors[0])
+
+
+# --- worker exception safety ---
+
+
+def test_unexpected_exception_resolves_as_transient_error():
+    """An unexpected exception from check() resolves the future instead of leaving it hanging."""
+    config = Config(max_workers=1)
+    service = URLCheckService(config)
+
+    def raising_check(self: MarkdownURL, **kwargs: object) -> URLCheckResult:
+        raise ValueError("boom")
+
+    try:
+        with patch.object(MarkdownURL, "check", raising_check):
+            future = service.submit(_url("https://exploding.example.com/1"))
+            result = future.result(timeout=5)
+    finally:
+        service.close()
+
+    assert result.status == "transient_error"
+
+
+# --- shutdown ---
+
+
+def test_close_joins_all_worker_threads():
+    """close() joins every worker thread; none remain alive afterwards."""
+    config = Config(max_workers=3)
+    service = URLCheckService(config)
+    workers = list(service._workers)  # noqa: SLF001 - internal, but this is a whitebox test
+    assert all(worker.is_alive() for worker in workers)
+    service.close()
+    assert all(not worker.is_alive() for worker in workers)


### PR DESCRIPTION
- Dedupe URL checks across files instead of checking the same link repeatedly.
- Add per-host request pacing and a circuit breaker for rate limiting.
- Overlap file checks with an adaptive in-flight window.

fixes #122 